### PR TITLE
feat: add Google Cloud Run deployment with custom domain

### DIFF
--- a/.github/workflows/cloudrun-deploy.yml
+++ b/.github/workflows/cloudrun-deploy.yml
@@ -17,9 +17,9 @@ on:
 
 env:
   PROJECT_ID: 'denhamparry-talks'
-  REGION: 'europe-west2'  # London
+  REGION: 'europe-west1'  # Belgium (supports domain mappings)
   SERVICE_NAME: 'talks'
-  ARTIFACT_REGISTRY: 'europe-west2-docker.pkg.dev'
+  ARTIFACT_REGISTRY: 'europe-west1-docker.pkg.dev'
   REPOSITORY: 'talks'
   IMAGE_NAME: 'talks'
 
@@ -107,5 +107,5 @@ jobs:
 
           echo "**Service URL:** $SERVICE_URL" >> $GITHUB_STEP_SUMMARY
           echo "**Custom Domain:** https://talks.denhamparry.co.uk (after DNS setup)" >> $GITHUB_STEP_SUMMARY
-          echo "**Region:** ${{ env.REGION }} (London)" >> $GITHUB_STEP_SUMMARY
+          echo "**Region:** ${{ env.REGION }} (Belgium)" >> $GITHUB_STEP_SUMMARY
           echo "**Image:** $IMAGE_URL" >> $GITHUB_STEP_SUMMARY

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ docker build --target production -t talks:latest .
 Presentations are automatically deployed to **Google Cloud Run** when changes are pushed to the main branch.
 
 - **Production URL:** [talks.denhamparry.co.uk](https://talks.denhamparry.co.uk)
-- **Region:** europe-west2 (London)
+- **Region:** europe-west1 (Belgium)
 - **Platform:** Google Cloud Run (serverless)
 - **Cost:** $0/month (within free tier)
 
@@ -278,7 +278,7 @@ Presentations are automatically deployed to **Google Cloud Run** when changes ar
 # Deploy latest image to Cloud Run
 gcloud run deploy talks \
   --image=ghcr.io/denhamparry/talks:latest \
-  --region=europe-west2 \
+  --region=europe-west1 \
   --project=denhamparry-talks
 ```
 

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -37,7 +37,7 @@ GitHub → Docker Build → GHCR → Cloud Run → talks.denhamparry.co.uk
 
 3. **Deploy to Cloud Run**
    - Triggers `.github/workflows/cloudrun-deploy.yml`
-   - Deploys to europe-west2 (London)
+   - Deploys to europe-west1 (Belgium)
    - Scales 0-10 instances automatically
 
 4. **Available globally**
@@ -151,7 +151,7 @@ gcloud artifacts repositories describe talks \
 ### Step 5: Create Service Accounts
 
 ```bash
-export REGION="europe-west2"  # London
+export REGION="europe-west1"  # Belgium (supports domain mappings)
 export SERVICE_NAME="talks"
 
 # Service account for Cloud Run service (runs the container)
@@ -420,7 +420,7 @@ git push origin main
 # Deploy specific image tag
 gcloud run deploy talks \
   --image=ghcr.io/denhamparry/talks:main \
-  --region=europe-west2 \
+  --region=europe-west1 \
   --project=denhamparry-talks
 ```
 
@@ -631,7 +631,7 @@ gcloud billing budgets update BUDGET_ID \
 ```bash
 gcloud run services update talks \
   --min-instances=1 \
-  --region=europe-west2
+  --region=europe-west1
 ```
 
 ### Image Size Too Large
@@ -673,7 +673,7 @@ If presentations are large or complex:
 gcloud run services update talks \
   --memory=512Mi \
   --cpu=2 \
-  --region=europe-west2
+  --region=europe-west1
 ```
 
 **Cost impact:** Increases compute costs, but still likely within free tier.
@@ -767,7 +767,7 @@ gcloud run services add-iam-policy-binding talks \
 For issues with deployment:
 
 1. Check [Troubleshooting](#troubleshooting) section
-2. Review Cloud Run logs: `gcloud run services logs read talks --region=europe-west2`
+2. Review Cloud Run logs: `gcloud run services logs read talks --region=europe-west1`
 3. Check GitHub Actions logs: `gh run view --log`
 4. Open an issue in the repository
 


### PR DESCRIPTION
## Summary

Implements complete Google Cloud Run deployment infrastructure with custom domain support for `talks.denhamparry.co.uk`. This enables automatic serverless deployment of MARP presentations when changes are pushed to main.

## Changes

### Infrastructure

- **Cloud Run Deployment Workflow** (`.github/workflows/cloudrun-deploy.yml`)
  - Authenticates using Workload Identity Federation (keyless)
  - Pulls image from GHCR and pushes to Artifact Registry
  - Deploys to europe-west1 (Belgium) - required for domain mappings
  - Runs health checks and verification
  - Scales 0-10 instances automatically

- **Docker Configuration**
  - Updated Dockerfile for Cloud Run compatibility:
    - Dynamic `PORT` environment variable support
    - Nginx template with envsubst for port substitution
    - Health check endpoint on `$PORT/health`
    - Include scripts directory for index generation
  - Modified docker-publish workflow to disable attestations (not supported for private repos)

### Documentation

- **Comprehensive Deployment Guide** (`docs/deployment-guide.md`, 779 lines)
  - Complete setup from scratch (GCP project, billing, APIs)
  - Workload Identity Federation configuration
  - Service account setup with proper IAM roles
  - Artifact Registry repository creation
  - Domain mapping with Cloudflare DNS
  - Cost management and budget alerts
  - Troubleshooting guide
  - Advanced configuration options

- **Updated README** with deployment section:
  - Quick start commands
  - Architecture overview
  - Manual deployment instructions
  - Links to full deployment guide

### Architecture

```
GitHub → Build → GHCR → Cloud Run → talks.denhamparry.co.uk
   ↓       ↓       ↓        ↓              ↓
 Push   Docker  Store   Deploy        Custom Domain
 main   Image  ghcr.io  (Belgium)     (Cloudflare)
```

### Region Selection

Migrated to **europe-west1 (Belgium)** because:
- ✅ Supports Cloud Run domain mappings
- ✅ Similar latency to UK (~20ms difference)
- ❌ europe-west2 (London) does NOT support domain mappings

## Testing

- [x] Docker build succeeds (local and CI)
- [x] Health check endpoint responds correctly
- [x] Nginx serves presentations and index
- [x] Multi-architecture images (amd64, arm64)
- [x] Pre-commit hooks pass
- [x] All documentation updated

## Deployment

After merge, the following will happen automatically:
1. GitHub Actions builds Docker image
2. Publishes to `ghcr.io/denhamparry/talks:latest`
3. Deploys to Cloud Run service `talks`
4. Available at `https://talks.denhamparry.co.uk`

## Cost

- **Expected:** $0/month (within Cloud Run free tier)
- **Budget:** £10/month (~$12) with alerts at 50%, 90%, 100%, 110%
- **Free tier:** 2M requests/month, 360k GB-seconds/month

## Post-Merge Setup Required

The following manual steps are required once before the workflow can run:

1. **Complete GCP setup** (if not already done):
   - Follow `docs/deployment-guide.md` Steps 1-7
   - Configure Workload Identity Federation
   - Add GitHub Secrets (GCP_WORKLOAD_IDENTITY_PROVIDER, GCP_SERVICE_ACCOUNT)

2. **Deploy custom domain** (if not already done):
   - Follow `docs/deployment-guide.md` Steps 8-9
   - Configure Cloudflare DNS CNAME record
   - Wait for SSL certificate provisioning (5-15 minutes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)