### PR TITLE
fix(slides): correct technical details in Road to Multitenancy presentation

### DIFF
--- a/slides/2026-01-14-road-to-multitenancy.md
+++ b/slides/2026-01-14-road-to-multitenancy.md
@@ -244,7 +244,6 @@ Speaker Notes:
 - Memory: ~5MB overhead vs ~100MB for traditional VMs
 - KVM virtualization: hardware-level isolation guarantee
 - BUT: still has VM layer, just optimized
-- Limited to Linux guests: no Windows support
 - Nested virtualization: need specific host configuration in cloud
 - Purpose-built for serverless: not general-purpose container runtime
 - Trade-off: better than traditional VMs for startup time, but still not container-native
@@ -409,7 +408,7 @@ Speaker Notes:
 - Technical architecture: how Edera achieves security + performance
 - CRI compatible: works with any Kubernetes distribution (EKS, GKE, AKS, vanilla)
 - Zone isolation: each container gets its own "zone" (lightweight VM) with full Linux kernel
-- Type-1 hypervisor: microkernel written in MISRA C for minimal attack surface
+- Type-1 hypervisor: microkernel written in Rust for minimal attack surface
 - Paravirtualization: guest kernel uses hypercalls for privileged operations
 - Unlike gVisor (intercepts all syscalls), Edera delegates through hypervisor
 - Unlike Kata/Firecracker (traditional VMs), Edera uses paravirtualization for efficiency
@@ -734,9 +733,6 @@ Speaker Notes:
 
   Q: "Is it production-ready?"
   A: Visit edera.dev for current status and case studies.
-
-  Q: "What about Windows containers?"
-  A: Currently focused on Linux containers, the primary multi-tenant use case.
 - Available after the talk for one-on-one discussions
 - Point them to resources on the slide for self-service learning
 - Thank event organizers and venue


### PR DESCRIPTION
## Summary

This PR corrects technical inaccuracies in the Road to Multitenancy presentation to ensure accurate information is presented.

## Changes Made

- **Edera hypervisor correction**: Updated description to reflect that the microkernel is written in Rust, not MISRA C
- **Firecracker limitation removed**: Deleted outdated note stating "Limited to Linux guests: no Windows support" from the Firecracker section
- **Q&A cleanup**: Removed Windows containers question from the Q&A section as it's no longer relevant

## Motivation

These corrections ensure the presentation accurately reflects:
1. Current Edera architecture (Rust-based microkernel)
2. Current Firecracker capabilities (supports more than just Linux guests)
3. Relevant Q&A content for the target audience

## Testing

- [x] Changes reviewed for technical accuracy
- [x] Pre-commit hooks passed
- [x] No build/syntax errors introduced

## Breaking Changes

None - documentation/presentation updates only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)