### PR TITLE
feat(slides): add architecture diagrams to Road to Multitenancy presentation

### DIFF
--- a/docs/plan/issues/78_add_architecture_diagrams_to_road_to_multitenancy_presentation.md
+++ b/docs/plan/issues/78_add_architecture_diagrams_to_road_to_multitenancy_presentation.md
@@ -1,0 +1,604 @@
+# GitHub Issue #78: Add architecture diagrams to Road to Multitenancy presentation
+
+**Issue:** [#78](https://github.com/denhamparry/talks/issues/78)
+**Status:** Reviewed (Approved)
+**Date:** 2026-02-27
+
+## Problem Statement
+
+The Road to Multitenancy presentation (`slides/2026-01-14-road-to-multitenancy.md`)
+needs three new visual architecture diagrams to help the audience better understand
+multitenancy concepts and implementation patterns.
+
+### Current Behavior
+
+- No dedicated architecture diagrams exist for:
+  - High-level multitenancy system component layout
+  - Tenant data isolation pattern comparisons
+  - Deployment topology and infrastructure overview
+- Issue #75 (Complete) added existing Edera performance/architecture assets but did
+  not create new purpose-built multitenancy diagrams
+- The presentation is strong on text and existing Edera branding diagrams but lacks
+  original architecture illustrations
+
+### Expected Behavior
+
+Three new SVG diagram files created and integrated into the presentation:
+
+1. **System Architecture Overview** — high-level multitenancy system components
+2. **Data Isolation Patterns** — tenant data segregation strategies
+3. **Deployment Architecture** — infrastructure and deployment topology
+
+## Current State Analysis
+
+### Relevant Files
+
+- **Presentation:** `slides/2026-01-14-road-to-multitenancy.md` (740 lines, 22 slides)
+- **Existing assets:** `slides/assets/diagrams/` — 22 Edera brand/benchmark diagrams
+- **Tenant assets:** `slides/assets/2026-01-14-road-to-multitenancy/` — QR code only
+- **Theme:** `themes/edera-v2.css` — Edera V2 colours confirmed
+- **Build:** `Makefile` + npm scripts (`make build`, `make build-pdf`)
+
+### Theme Colours (from `themes/edera-v2.css`)
+
+```css
+--edera-dark-teal:   #013a3b   /* backgrounds, text */
+--edera-light-mint:  #d0fdf2   /* content slide backgrounds */
+--edera-cyan-accent: #02f4d5   /* headings, emphasis */
+--edera-white:       #ffffff
+```
+
+### Presentation Structure
+
+| Slide | Class   | Content |
+|-------|---------|---------|
+| 1     | title   | Title |
+| 2–3   | content | Multi-tenancy problem |
+| 4     | content | Scale vs Isolation + attack diagram |
+| 5–10  | content | Six current approaches |
+| 11    | content | Comparison matrix |
+| 12    | dark    | Enter Edera |
+| 13    | content | How Edera works (architecture) |
+| 14–15 | dark    | Benefits |
+| 16    | content | Platform engineering impact |
+| 17–18 | dark    | Use cases |
+| 19    | content | Conclusion |
+| 20    | title   | Q&A |
+
+### Asset Directory Convention
+
+The issue requests `slides/assets/road-to-multitenancy/`. However, the existing
+convention for talk-specific assets uses date-prefix directories, e.g.
+`slides/assets/2026-01-14-road-to-multitenancy/`. To respect the issue request while
+noting the convention, new files go in `slides/assets/road-to-multitenancy/` as
+specified.
+
+## Solution Design
+
+### Approach
+
+Create three new **SVG diagram files** and add corresponding slides to the
+presentation. SVG is chosen because:
+
+- Vector format: crisp at any slide resolution/scale
+- CSS-compatible: can use Edera V2 hex colours directly
+- Code-as-text: version-controllable, no binary tools required
+- MARP support: renders via standard `![alt](path)` markdown image syntax
+
+### Diagram 1: System Architecture Overview
+
+**File:** `slides/assets/road-to-multitenancy/system-architecture-overview.svg`
+
+**Content:** High-level view of a Kubernetes multi-tenant cluster showing:
+
+- Kubernetes control plane
+- Worker nodes running Edera
+- Multiple tenant workloads (Pod icons) isolated in their own zones
+- External traffic entering through an ingress/gateway
+- Edera hypervisor layer between host OS and tenant zones
+
+**Placement in slides:** New slide after slide 13 ("How Edera Works: Technical
+Overview"), as the diagram directly visualises what is described there.
+
+**Colours:**
+- Background: `#d0fdf2` (light mint)
+- Kubernetes/cluster border: `#013a3b` (dark teal)
+- Edera zone boxes: `#02f4d5` (cyan accent)
+- Labels: `#013a3b`
+
+### Diagram 2: Data Isolation Patterns
+
+**File:** `slides/assets/road-to-multitenancy/data-isolation-patterns.svg`
+
+**Content:** Three-column comparison of tenant data isolation strategies:
+
+- Column 1 — **Database-per-tenant**: separate database icons per tenant
+- Column 2 — **Schema-per-tenant**: single database, multiple schemas
+- Column 3 — **Row-level security**: single schema, rows labelled with tenant IDs
+
+This provides context on the SaaS platform use case mentioned in slides 16–18
+("Platform Engineering Impact", "Edera for Containers: Use Cases").
+
+**Placement in slides:** New slide inserted before or as part of the "Platform
+Engineering Impact" section (after current slide 16), to set context for SaaS
+multi-tenancy data isolation alongside container isolation.
+
+**Colours:** Same palette as above; column headers in `#013a3b`, column backgrounds
+alternating between `#d0fdf2` and `#013a3b` with white text.
+
+### Diagram 3: Deployment Architecture
+
+**File:** `slides/assets/road-to-multitenancy/deployment-architecture.svg`
+
+**Content:** Infrastructure topology showing:
+
+- Cloud provider layer (or on-prem) at the bottom
+- VM/bare metal nodes running Edera hypervisor
+- Kubernetes control plane on a separate node
+- Worker nodes with multiple Edera zones (one per tenant workload)
+- Networking layer: external ingress → gateway → zone → container
+- Labels: "Tenant A", "Tenant B", "Tenant C" in separate zones
+
+**Placement in slides:** New slide after the System Architecture Overview slide,
+forming a "how it deploys" follow-on to "how it works".
+
+**Colours:** Same palette; zone boundaries highlighted in `#02f4d5`.
+
+### Slide Additions
+
+Three new slides to be inserted after slide 13 (How Edera Works):
+
+```markdown
+---
+
+<!-- _class: content -->
+
+# Multi-Tenant System Architecture
+
+![System architecture overview](./assets/road-to-multitenancy/system-architecture-overview.svg)
+
+---
+
+<!-- _class: content -->
+
+# Deployment Architecture
+
+![Deployment architecture](./assets/road-to-multitenancy/deployment-architecture.svg)
+
+---
+
+<!-- _class: content -->
+
+# Data Isolation Patterns
+
+![Data isolation patterns](./assets/road-to-multitenancy/data-isolation-patterns.svg)
+```
+
+### Benefits
+
+- Provides visual anchors for key discussion points
+- Audiences with varying technical backgrounds can follow the architecture
+- Diagrams serve as reference material post-presentation
+- Reuses Edera V2 colour palette for brand consistency
+
+## Implementation Plan
+
+### Step 1: Create asset directory
+
+**Command:**
+
+```bash
+mkdir -p slides/assets/road-to-multitenancy
+```
+
+### Step 2: Create System Architecture Overview SVG
+
+**File:** `slides/assets/road-to-multitenancy/system-architecture-overview.svg`
+
+**SVG structure:**
+
+- Canvas: 1200×675 (16:9, matches MARP default)
+- Top section: Kubernetes control plane box (dark teal)
+- Middle section: two worker nodes side by side
+- Each worker node: Edera hypervisor layer, two zone boxes (cyan accent)
+- Bottom: shared host OS bar (dark teal)
+- Right side: external traffic arrow pointing to ingress
+- Legend: zone = "Tenant Workload"
+
+**Testing:**
+
+```bash
+make build
+# verify SVG renders on slide
+```
+
+### Step 3: Create Deployment Architecture SVG
+
+**File:** `slides/assets/road-to-multitenancy/deployment-architecture.svg`
+
+**SVG structure:**
+
+- Top: Cloud/on-prem bar
+- Second row: control plane VM + 3 worker VMs
+- Inside each worker VM: Edera hypervisor label + 2 zones
+- Each zone: Container icon + "Tenant N" label
+- Arrows: external ingress → gateway → zones
+- Labels for each layer
+
+### Step 4: Create Data Isolation Patterns SVG
+
+**File:** `slides/assets/road-to-multitenancy/data-isolation-patterns.svg`
+
+**SVG structure:**
+
+- Three equal columns with headers
+- Column 1 (DB-per-tenant): three separate database cylinders, each labelled
+  "Tenant A DB", "Tenant B DB", "Tenant C DB"
+- Column 2 (Schema-per-tenant): one database cylinder with three inner sections
+  labelled "Schema A", "Schema B", "Schema C"
+- Column 3 (Row-level security): one database cylinder with rows coloured and
+  labelled "Tenant A Row", "Tenant B Row", "Tenant C Row"
+- Dividers between columns in dark teal
+- Title row: "Database-per-Tenant", "Schema-per-Tenant", "Row-Level Security"
+
+### Step 5: Add new slides to presentation
+
+**File:** `slides/2026-01-14-road-to-multitenancy.md`
+
+Insert three new slides immediately after the "How Edera Works: Technical Overview"
+slide (after line ~422 in current file). The new slides reference the SVGs via
+relative paths and include speaker notes.
+
+**Speaker notes for System Architecture slide:**
+
+```
+- Point to the Edera hypervisor layer between host OS and tenant zones
+- Each cyan box is a "zone" — a lightweight VM with its own kernel
+- No shared kernel means no shared attack surface
+- This is what enables true multi-tenancy without trade-offs
+```
+
+**Speaker notes for Deployment Architecture slide:**
+
+```
+- Show infrastructure from cloud provider to tenant container
+- Each level provides isolation: cloud VMs → Edera zones → containers
+- A single cluster can serve many tenants safely
+- Kubernetes manages the orchestration; Edera handles the isolation
+```
+
+**Speaker notes for Data Isolation slide:**
+
+```
+- Three common SaaS data isolation strategies
+- DB-per-tenant: strongest isolation, highest cost
+- Schema-per-tenant: moderate isolation, shared infrastructure
+- Row-level: cheapest, requires careful application-level controls
+- Edera operates at the infrastructure layer, complementing all three
+```
+
+### Step 6: Build and verify
+
+**Commands:**
+
+```bash
+make build
+make build-pdf
+make test-smoke
+```
+
+**Verification:**
+
+```bash
+# Confirm SVG files exist
+ls slides/assets/road-to-multitenancy/
+
+# Confirm images render in HTML
+grep -c '<img' dist/2026-01-14-road-to-multitenancy.html
+
+# Check for broken image refs
+grep '!\[' slides/2026-01-14-road-to-multitenancy.md
+```
+
+### Step 7: Run pre-commit hooks
+
+```bash
+pre-commit run --all-files
+```
+
+Fix any trailing whitespace, end-of-file, or markdown lint issues before commit.
+
+## Testing Strategy
+
+### Unit Testing
+
+**Image link validation:**
+
+```bash
+grep -o '\./assets/road-to-multitenancy/[^)]*' \
+  slides/2026-01-14-road-to-multitenancy.md | while read p; do
+  f="slides/${p#./}"
+  [ -f "$f" ] || echo "Missing: $f"
+done
+```
+
+**Expected:** No missing files reported.
+
+### Integration Testing
+
+**Test Case 1: HTML Build**
+
+1. `make clean`
+2. `make build`
+3. Open `dist/2026-01-14-road-to-multitenancy.html`
+4. Navigate to new slides (14–16), verify SVG diagrams render
+5. Check all existing slides still display correctly
+
+**Expected:** All three new diagram slides visible, no broken images.
+
+**Test Case 2: PDF Build**
+
+1. `make build-pdf`
+2. Open `dist/2026-01-14-road-to-multitenancy.pdf`
+3. Check pages for the three new diagram slides
+
+**Expected:** SVGs render in PDF, total file size <25MB.
+
+**Test Case 3: Smoke Tests**
+
+```bash
+make test-smoke
+```
+
+**Expected:** All smoke tests pass.
+
+### Regression Testing
+
+- [ ] QR code slide still displays
+- [ ] Footer with event details appears on all slides
+- [ ] Edera V2 theme applies correctly
+- [ ] Speaker notes preserved
+- [ ] Existing diagrams (from issue #75) still render
+- [ ] Comparison matrix table still displays
+- [ ] Pagination correct (slide count increases by 3)
+
+## Success Criteria
+
+- [ ] `slides/assets/road-to-multitenancy/system-architecture-overview.svg` created
+- [ ] `slides/assets/road-to-multitenancy/data-isolation-patterns.svg` created
+- [ ] `slides/assets/road-to-multitenancy/deployment-architecture.svg` created
+- [ ] Diagrams follow Edera V2 colour scheme (#013a3b, #d0fdf2, #02f4d5)
+- [ ] Three new slides added to presentation referencing the diagrams
+- [ ] Diagrams placed in appropriate sections of the presentation
+- [ ] Image files stored in `slides/assets/road-to-multitenancy/`
+- [ ] Build process successfully generates HTML with new diagrams
+- [ ] Build process successfully generates PDF with new diagrams
+- [ ] All smoke tests pass
+- [ ] Pre-commit hooks pass
+- [ ] Speaker notes reference diagrams appropriately
+
+## Files Modified
+
+1. `slides/2026-01-14-road-to-multitenancy.md` — add 3 new slides with diagram refs
+   and speaker notes
+
+## Files Created
+
+1. `slides/assets/road-to-multitenancy/system-architecture-overview.svg`
+2. `slides/assets/road-to-multitenancy/data-isolation-patterns.svg`
+3. `slides/assets/road-to-multitenancy/deployment-architecture.svg`
+
+## Related Issues and Tasks
+
+### Depends On
+
+- Issue #75 (Complete) — integrated existing Edera diagram assets; this issue creates
+  new originals
+
+### Blocks
+
+- None
+
+### Related
+
+- Issue #75 — previous diagram integration
+- Issue #68 — earlier slide deck update
+- Issue #72 — factual accuracy review
+
+### Enables
+
+- Better audience engagement during live presentation
+- More effective communication of multitenancy concepts
+- Complete visual coverage of system architecture topics
+
+## References
+
+- [GitHub Issue #78](https://github.com/denhamparry/talks/issues/78)
+- Presentation: `slides/2026-01-14-road-to-multitenancy.md`
+- Theme: `themes/edera-v2.css`
+- Prior diagrams: `slides/assets/diagrams/README.md`
+- MARP image syntax: https://marpit.marp.app/image-syntax
+
+## Notes
+
+### Key Insights
+
+1. **SVG is the right format** — vector, version-controllable, themed with CSS colours
+2. **Three new slides** — one per diagram, inserted after "How Edera Works"
+3. **Directory naming** — using `road-to-multitenancy/` as specified in issue, not
+   date-prefixed variant
+4. **Data Isolation Patterns** — SaaS-level data isolation is a complement to
+   Edera's container-level isolation; both dimensions are relevant to platform
+   engineering use cases
+
+### Alternative Approaches Considered
+
+1. **Reuse existing Edera diagrams** — Already done in issue #75; issue #78 specifically
+   requests new architecture diagrams ❌
+2. **Mermaid diagrams inline** — MARP supports Mermaid but renders inconsistently across
+   PDF/HTML outputs; SVG files are more reliable ❌
+3. **Chosen: SVG files** — Reliable rendering in both HTML and PDF, themed with Edera V2
+   colours, stored as version-controlled text ✅
+
+### Best Practices
+
+- **Alt text:** Always include descriptive alt text for accessibility
+- **Viewbox:** Set SVG `viewBox` to match 16:9 ratio (1200×675 or 800×450)
+- **Font:** Use system fonts (sans-serif) to avoid font-loading issues in MARP
+- **Path references:** Use relative paths (`./assets/road-to-multitenancy/`) not absolute
+
+---
+
+## Plan Review
+
+**Reviewer:** Claude Code (workflow-research-plan)
+**Review Date:** 2026-02-27
+**Original Plan Date:** 2026-02-27
+
+### Review Summary
+
+- **Overall Assessment:** Approved
+- **Confidence Level:** High
+- **Recommendation:** Proceed to implementation
+
+### Strengths
+
+1. **Correct format choice** — SVG is the right format for MARP slides. Vector
+   format stays crisp at all resolutions, is version-controllable as text, and
+   renders reliably in both HTML and PDF output via Chromium.
+
+2. **Asset pipeline validated** — The `copy-assets` script (`"cp -r slides/assets/*
+   dist/assets/"` in `package.json`) will automatically copy
+   `slides/assets/road-to-multitenancy/` to `dist/assets/road-to-multitenancy/`
+   after the HTML build, matching how all existing diagrams are served.
+
+3. **Smoke tests will self-validate** — `scripts/smoke-test.js` dynamically reads
+   every subdirectory of `slides/assets/` and verifies its contents are present in
+   `dist/assets/`. The new directory will be covered automatically with no changes
+   to the test script.
+
+4. **All acceptance criteria covered** — All seven acceptance criteria from issue
+   #78 are explicitly addressed in the Success Criteria section.
+
+5. **Theme colours verified** — Colours were cross-checked against
+   `themes/edera-v2.css` and match exactly.
+
+6. **Convention decision is justified** — Using `slides/assets/road-to-multitenancy/`
+   (as requested by the issue) rather than the date-prefixed convention is a
+   conscious, documented choice.
+
+### Gaps Identified
+
+1. **Gap: Slide placement inconsistency**
+   - **Impact:** Low
+   - **Detail:** The Slide Additions section says all three slides are inserted
+     "after slide 13 (How Edera Works)", but the Diagram 2 description places the
+     Data Isolation slide "after slide 16 (Platform Engineering Impact)". These
+     contradict each other.
+   - **Recommendation:** Pick one consistent ordering. The logical narrative flow
+     is: Architecture Overview → Deployment Architecture (both after slide 13),
+     then Data Isolation Patterns after slide 16 (where SaaS use cases are
+     discussed). Update Step 5 of the implementation plan to reflect this split
+     insertion.
+
+2. **Gap: PDF build path resolution not explicitly verified**
+   - **Impact:** Low
+   - **Detail:** `build:pdf` runs `marp -I slides/ --pdf -o dist/` without
+     running `copy-assets` first. For PDF mode, MARP's Chromium instance resolves
+     image paths relative to the source markdown file location (`slides/`), so
+     `./assets/road-to-multitenancy/` resolves to `slides/assets/road-to-multitenancy/`
+     — which is correct. However, this is not explicitly verified in the plan.
+   - **Recommendation:** Add a note to Step 6 confirming that PDF builds read
+     images from `slides/assets/` (source path), not `dist/assets/`, so the
+     directory just needs to exist before `build:pdf` runs.
+
+### Edge Cases Not Covered
+
+1. **SVG font rendering variation**
+   - **Current Plan:** Advises using `sans-serif` system fonts, which is correct.
+   - **Scenario:** Different environments (CI vs local) may render fonts slightly
+     differently. Text in SVGs can overflow boxes if font metrics differ.
+   - **Recommendation:** Keep SVG labels short (< 20 chars per label), and use
+     explicit `font-size` attributes on all `<text>` elements. Test PDF output
+     after creating the SVGs.
+
+2. **MARP image sizing on slides with only a diagram**
+   - **Current Plan:** Slides contain only a heading and the image reference.
+   - **Scenario:** MARP will size the image to available space, but very wide or
+     very tall SVGs may not fill the slide as expected. Using `width: 100%` inside
+     the SVG `<image>` markdown hint may be needed.
+   - **Recommendation:** Consider using MARP image sizing syntax:
+     `![System architecture overview w:900](./assets/...)` to explicitly control
+     image width.
+
+### Alternative Approaches Considered
+
+1. **Mermaid inline diagrams**
+   - **Pros:** No separate files needed, diagrams live in the markdown
+   - **Cons:** MARP Mermaid support renders via JavaScript at runtime, which is
+     inconsistent in PDF mode; Mermaid diagrams cannot use custom brand colours
+     as easily
+   - **Verdict:** SVG files are the better choice ✅ (plan's choice is correct)
+
+2. **PNG raster images (generated externally)**
+   - **Pros:** Predictable rendering, any tool can produce them
+   - **Cons:** Not version-controllable as text, lose crispness if slide
+     dimensions change, require binary files in git
+   - **Verdict:** SVG files are superior for this use case ✅
+
+### Risks and Concerns
+
+1. **Data Isolation Patterns diagram — narrative fit**
+   - **Likelihood:** Medium
+   - **Impact:** Low
+   - **Detail:** The presentation focuses entirely on _container/infrastructure_
+     isolation (Kata, gVisor, Edera zones). Introducing a diagram about
+     _data-layer_ isolation (database-per-tenant, schema-per-tenant, row-level
+     security) is a different abstraction level. It may confuse the audience by
+     appearing to shift the topic. The issue explicitly requests this diagram, so
+     it must be included — but placement and speaker notes need to make the
+     connection clear.
+   - **Mitigation:** The speaker notes in the plan already address this: "Edera
+     operates at the infrastructure layer, complementing all three [data isolation
+     strategies]." Keep this framing. Place this slide in the use-cases section
+     (after slide 16/17) rather than after the technical architecture slides, so
+     it reads as "here's the broader multi-tenancy picture" rather than a
+     technical deep-dive.
+
+2. **Issue references wrong asset directory**
+   - **Likelihood:** N/A (informational)
+   - **Detail:** The issue body says "Existing Edera diagrams are available in
+     `slides/assets/ederav2/`" but that directory only contains the logo PNG.
+     The actual architecture diagrams are in `slides/assets/diagrams/`. The plan
+     correctly identifies the diagrams directory — this is not a risk but worth
+     noting as confirmation.
+
+### Required Changes
+
+No blocking changes required. The plan is implementable as written with the
+following clarification recommended before coding:
+
+- [ ] **Clarify slide insertion points** — Decide whether to insert all three
+  slides after slide 13, or split (Architecture Overview + Deployment after 13,
+  Data Isolation after 16). Update Step 5 to be unambiguous.
+
+### Optional Improvements
+
+- [ ] Use MARP image width hints (e.g. `w:900`) on diagram slides to control
+  sizing explicitly
+- [ ] Keep SVG text labels short and use explicit `font-size` on all `<text>`
+  elements to ensure consistent rendering across environments
+- [ ] Add a note in Step 6 confirming PDF builds read from `slides/assets/` path
+
+### Verification Checklist
+
+- [x] Solution addresses root cause identified in GitHub issue
+- [x] All acceptance criteria from issue are covered
+- [x] Implementation steps are specific and actionable
+- [x] File paths and code references are accurate
+- [x] Asset copy pipeline verified in `package.json`
+- [x] Smoke test coverage confirmed in `scripts/smoke-test.js`
+- [x] SVG format choice validated for MARP HTML and PDF output
+- [x] Theme colours cross-checked against `themes/edera-v2.css`
+- [x] Directory naming decision documented
+- [x] Regression testing covers existing slides

--- a/docs/plan/issues/78_add_architecture_diagrams_to_road_to_multitenancy_presentation.md
+++ b/docs/plan/issues/78_add_architecture_diagrams_to_road_to_multitenancy_presentation.md
@@ -1,7 +1,7 @@
 # GitHub Issue #78: Add architecture diagrams to Road to Multitenancy presentation
 
 **Issue:** [#78](https://github.com/denhamparry/talks/issues/78)
-**Status:** Reviewed (Approved)
+**Status:** Complete
 **Date:** 2026-02-27
 
 ## Problem Statement

--- a/slides/2026-01-14-road-to-multitenancy.md
+++ b/slides/2026-01-14-road-to-multitenancy.md
@@ -422,6 +422,47 @@ Speaker Notes:
 
 ---
 
+<!-- _class: content -->
+
+# Multi-Tenant System Architecture
+
+![System architecture overview showing Kubernetes cluster with Edera zones](./assets/road-to-multitenancy/system-architecture-overview.svg)
+
+<!--
+Speaker Notes:
+- This is what the Edera architecture looks like inside a Kubernetes cluster
+- Control Plane manages the cluster — unchanged, standard Kubernetes
+- Worker Nodes run the Edera Type-1 Hypervisor
+- Each Zone is a lightweight VM with its own Linux kernel
+- Point to the cyan boxes — those are Edera Zones, one per tenant
+- No shared kernel between zones — Tenant A and Tenant B cannot affect each other
+- This is the key difference from standard container runtimes (shared kernel)
+- Same familiar Kubernetes primitives: Pods, Deployments, Services
+- The isolation is transparent to the application
+-->
+
+---
+
+<!-- _class: content -->
+
+# Deployment Architecture
+
+![Deployment topology showing cloud infrastructure, worker nodes, and tenant zones](./assets/road-to-multitenancy/deployment-architecture.svg)
+
+<!--
+Speaker Notes:
+- Tenant requests arrive at the Ingress / Load Balancer as normal
+- Traffic is routed to the appropriate Edera Zone on any worker node
+- Each worker node runs the Edera Hypervisor and hosts multiple zones
+- Each zone runs one tenant's container workload in full isolation
+- Worker nodes scale horizontally as more tenants are added
+- Cloud or bare metal — Edera works on both
+- Key point: a single Kubernetes cluster handles all tenants safely
+- No need for separate clusters per tenant — cost and ops efficiency
+-->
+
+---
+
 <!-- _class: dark -->
 
 # Benefits: Security + Performance
@@ -518,6 +559,27 @@ Speaker Notes:
 - Use case 4: Edge - limited resources, need density AND security
 - Bottom line: build platforms that are both secure and fast
 - No more "we can't do that for security reasons" blockers
+-->
+
+---
+
+<!-- _class: content -->
+
+# Tenant Data Isolation Patterns
+
+![Data isolation patterns comparing database-per-tenant, schema-per-tenant, and row-level security](./assets/road-to-multitenancy/data-isolation-patterns.svg)
+
+<!--
+Speaker Notes:
+- SaaS platforms use different data isolation strategies at the application layer
+- Database-per-tenant: strongest isolation, highest cost — separate DB per customer
+- Schema-per-tenant: moderate isolation, shared infrastructure — one DB, separate schemas
+- Row-level security: cheapest, policy filters which rows each tenant can read
+- These are APPLICATION-level isolation patterns
+- Edera operates at the INFRASTRUCTURE layer — it complements all three approaches
+- Regardless of which data strategy you choose, Edera ensures containers are isolated
+- Point: multi-tenancy is a spectrum — Edera handles the infrastructure layer,
+  your data strategy handles the application layer
 -->
 
 ---

--- a/slides/assets/road-to-multitenancy/data-isolation-patterns.svg
+++ b/slides/assets/road-to-multitenancy/data-isolation-patterns.svg
@@ -1,0 +1,144 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 580" font-family="sans-serif">
+  <!-- Background -->
+  <rect width="1200" height="580" fill="#d0fdf2"/>
+
+  <!-- Title -->
+  <text x="600" y="38" text-anchor="middle" font-size="22" font-weight="bold" fill="#013a3b">
+    Tenant Data Isolation Patterns
+  </text>
+
+  <!-- Column dividers -->
+  <line x1="400" y1="55" x2="400" y2="560" stroke="#013a3b" stroke-width="1.5" stroke-dasharray="6,4"/>
+  <line x1="800" y1="55" x2="800" y2="560" stroke="#013a3b" stroke-width="1.5" stroke-dasharray="6,4"/>
+
+  <!-- ══════════════════════════════════════════ -->
+  <!-- COLUMN 1: Database-per-Tenant             -->
+  <!-- ══════════════════════════════════════════ -->
+  <rect x="20" y="55" width="360" height="44" rx="6" fill="#013a3b"/>
+  <text x="200" y="82" text-anchor="middle" font-size="16" font-weight="bold" fill="#d0fdf2">Database-per-Tenant</text>
+
+  <!-- DB A (cylinder) -->
+  <ellipse cx="200" cy="155" rx="70" ry="18" fill="#02f4d5" stroke="#013a3b" stroke-width="2"/>
+  <rect x="130" y="155" width="140" height="70" fill="#02f4d5" stroke="#013a3b" stroke-width="2"/>
+  <ellipse cx="200" cy="225" rx="70" ry="18" fill="#02f4d5" stroke="#013a3b" stroke-width="2"/>
+  <text x="200" y="196" text-anchor="middle" font-size="13" font-weight="bold" fill="#013a3b">Database A</text>
+  <text x="200" y="243" text-anchor="middle" font-size="12" fill="#013a3b" font-weight="bold">Tenant A only</text>
+
+  <!-- DB B (cylinder) -->
+  <ellipse cx="200" cy="305" rx="70" ry="18" fill="#02f4d5" stroke="#013a3b" stroke-width="2"/>
+  <rect x="130" y="305" width="140" height="70" fill="#02f4d5" stroke="#013a3b" stroke-width="2"/>
+  <ellipse cx="200" cy="375" rx="70" ry="18" fill="#02f4d5" stroke="#013a3b" stroke-width="2"/>
+  <text x="200" y="346" text-anchor="middle" font-size="13" font-weight="bold" fill="#013a3b">Database B</text>
+  <text x="200" y="393" text-anchor="middle" font-size="12" fill="#013a3b" font-weight="bold">Tenant B only</text>
+
+  <!-- DB C (cylinder) -->
+  <ellipse cx="200" cy="450" rx="70" ry="18" fill="#02f4d5" stroke="#013a3b" stroke-width="2"/>
+  <rect x="130" y="450" width="140" height="70" fill="#02f4d5" stroke="#013a3b" stroke-width="2"/>
+  <ellipse cx="200" cy="520" rx="70" ry="18" fill="#02f4d5" stroke="#013a3b" stroke-width="2"/>
+  <text x="200" y="491" text-anchor="middle" font-size="13" font-weight="bold" fill="#013a3b">Database C</text>
+  <text x="200" y="538" text-anchor="middle" font-size="12" fill="#013a3b" font-weight="bold">Tenant C only</text>
+
+  <!-- Tags for column 1 -->
+  <rect x="50" y="110" width="140" height="22" rx="4" fill="#013a3b" opacity="0.12"/>
+  <text x="120" y="125" text-anchor="middle" font-size="10" fill="#013a3b">Strongest isolation</text>
+  <rect x="50" y="135" width="140" height="22" rx="4" fill="#013a3b" opacity="0.12"/>
+  <text x="120" y="150" text-anchor="middle" font-size="10" fill="#013a3b">Highest cost</text>
+
+  <!-- ══════════════════════════════════════════ -->
+  <!-- COLUMN 2: Schema-per-Tenant               -->
+  <!-- ══════════════════════════════════════════ -->
+  <rect x="420" y="55" width="360" height="44" rx="6" fill="#013a3b"/>
+  <text x="600" y="82" text-anchor="middle" font-size="16" font-weight="bold" fill="#d0fdf2">Schema-per-Tenant</text>
+
+  <!-- Single large DB cylinder -->
+  <ellipse cx="600" cy="155" rx="100" ry="22" fill="#c8fff5" stroke="#013a3b" stroke-width="2"/>
+  <rect x="500" y="155" width="200" height="340" fill="#c8fff5" stroke="#013a3b" stroke-width="2"/>
+  <ellipse cx="600" cy="495" rx="100" ry="22" fill="#c8fff5" stroke="#013a3b" stroke-width="2"/>
+
+  <!-- Schema sections inside -->
+  <rect x="510" y="185" width="180" height="72" rx="4" fill="#02f4d5" stroke="#013a3b" stroke-width="1.5"/>
+  <text x="600" y="218" text-anchor="middle" font-size="13" font-weight="bold" fill="#013a3b">Schema A</text>
+  <text x="600" y="238" text-anchor="middle" font-size="11" fill="#013a3b">Tables for Tenant A</text>
+
+  <rect x="510" y="267" width="180" height="72" rx="4" fill="#02f4d5" stroke="#013a3b" stroke-width="1.5"/>
+  <text x="600" y="300" text-anchor="middle" font-size="13" font-weight="bold" fill="#013a3b">Schema B</text>
+  <text x="600" y="320" text-anchor="middle" font-size="11" fill="#013a3b">Tables for Tenant B</text>
+
+  <rect x="510" y="349" width="180" height="72" rx="4" fill="#02f4d5" stroke="#013a3b" stroke-width="1.5"/>
+  <text x="600" y="382" text-anchor="middle" font-size="13" font-weight="bold" fill="#013a3b">Schema C</text>
+  <text x="600" y="402" text-anchor="middle" font-size="11" fill="#013a3b">Tables for Tenant C</text>
+
+  <!-- Shared DB label -->
+  <text x="600" y="465" text-anchor="middle" font-size="12" fill="#013a3b">Shared Database</text>
+  <text x="600" y="482" text-anchor="middle" font-size="10" fill="#013a3b">one instance</text>
+
+  <!-- Tags for column 2 -->
+  <rect x="440" y="110" width="150" height="22" rx="4" fill="#013a3b" opacity="0.12"/>
+  <text x="515" y="125" text-anchor="middle" font-size="10" fill="#013a3b">Moderate isolation</text>
+  <rect x="440" y="135" width="150" height="22" rx="4" fill="#013a3b" opacity="0.12"/>
+  <text x="515" y="150" text-anchor="middle" font-size="10" fill="#013a3b">Shared infrastructure</text>
+
+  <!-- ══════════════════════════════════════════ -->
+  <!-- COLUMN 3: Row-Level Security              -->
+  <!-- ══════════════════════════════════════════ -->
+  <rect x="820" y="55" width="360" height="44" rx="6" fill="#013a3b"/>
+  <text x="1000" y="82" text-anchor="middle" font-size="16" font-weight="bold" fill="#d0fdf2">Row-Level Security</text>
+
+  <!-- Single DB cylinder (shared schema) -->
+  <ellipse cx="1000" cy="155" rx="100" ry="22" fill="#c8fff5" stroke="#013a3b" stroke-width="2"/>
+  <rect x="900" y="155" width="200" height="340" fill="#c8fff5" stroke="#013a3b" stroke-width="2"/>
+  <ellipse cx="1000" cy="495" rx="100" ry="22" fill="#c8fff5" stroke="#013a3b" stroke-width="2"/>
+
+  <!-- Rows inside DB (alternating by tenant colour) -->
+  <!-- Header row -->
+  <rect x="910" y="178" width="180" height="26" rx="2" fill="#013a3b" opacity="0.6"/>
+  <text x="960" y="196" text-anchor="middle" font-size="10" fill="#d0fdf2">tenant_id</text>
+  <text x="1040" y="196" text-anchor="middle" font-size="10" fill="#d0fdf2">data</text>
+  <!-- Tenant A rows -->
+  <rect x="910" y="208" width="180" height="24" rx="2" fill="#02f4d5" opacity="0.7"/>
+  <text x="960" y="224" text-anchor="middle" font-size="10" fill="#013a3b">A</text>
+  <text x="1040" y="224" text-anchor="middle" font-size="10" fill="#013a3b">record...</text>
+  <rect x="910" y="235" width="180" height="24" rx="2" fill="#02f4d5" opacity="0.7"/>
+  <text x="960" y="251" text-anchor="middle" font-size="10" fill="#013a3b">A</text>
+  <text x="1040" y="251" text-anchor="middle" font-size="10" fill="#013a3b">record...</text>
+  <!-- Tenant B rows -->
+  <rect x="910" y="262" width="180" height="24" rx="2" fill="#013a3b" opacity="0.2"/>
+  <text x="960" y="278" text-anchor="middle" font-size="10" fill="#013a3b">B</text>
+  <text x="1040" y="278" text-anchor="middle" font-size="10" fill="#013a3b">record...</text>
+  <rect x="910" y="289" width="180" height="24" rx="2" fill="#013a3b" opacity="0.2"/>
+  <text x="960" y="305" text-anchor="middle" font-size="10" fill="#013a3b">B</text>
+  <text x="1040" y="305" text-anchor="middle" font-size="10" fill="#013a3b">record...</text>
+  <!-- Tenant C rows -->
+  <rect x="910" y="316" width="180" height="24" rx="2" fill="#02f4d5" opacity="0.4"/>
+  <text x="960" y="332" text-anchor="middle" font-size="10" fill="#013a3b">C</text>
+  <text x="1040" y="332" text-anchor="middle" font-size="10" fill="#013a3b">record...</text>
+  <rect x="910" y="343" width="180" height="24" rx="2" fill="#02f4d5" opacity="0.4"/>
+  <text x="960" y="359" text-anchor="middle" font-size="10" fill="#013a3b">C</text>
+  <text x="1040" y="359" text-anchor="middle" font-size="10" fill="#013a3b">record...</text>
+  <!-- More rows -->
+  <rect x="910" y="370" width="180" height="24" rx="2" fill="#013a3b" opacity="0.2"/>
+  <text x="960" y="386" text-anchor="middle" font-size="10" fill="#013a3b">B</text>
+  <text x="1040" y="386" text-anchor="middle" font-size="10" fill="#013a3b">record...</text>
+  <rect x="910" y="397" width="180" height="24" rx="2" fill="#02f4d5" opacity="0.7"/>
+  <text x="960" y="413" text-anchor="middle" font-size="10" fill="#013a3b">A</text>
+  <text x="1040" y="413" text-anchor="middle" font-size="10" fill="#013a3b">record...</text>
+  <rect x="910" y="424" width="180" height="24" rx="2" fill="#02f4d5" opacity="0.4"/>
+  <text x="960" y="440" text-anchor="middle" font-size="10" fill="#013a3b">C</text>
+  <text x="1040" y="440" text-anchor="middle" font-size="10" fill="#013a3b">record...</text>
+
+  <!-- Shared DB label -->
+  <text x="1000" y="465" text-anchor="middle" font-size="12" fill="#013a3b">Shared DB + Schema</text>
+  <text x="1000" y="482" text-anchor="middle" font-size="10" fill="#013a3b">policy filters rows</text>
+
+  <!-- Tags for column 3 -->
+  <rect x="840" y="110" width="150" height="22" rx="4" fill="#013a3b" opacity="0.12"/>
+  <text x="915" y="125" text-anchor="middle" font-size="10" fill="#013a3b">Weakest isolation</text>
+  <rect x="840" y="135" width="150" height="22" rx="4" fill="#013a3b" opacity="0.12"/>
+  <text x="915" y="150" text-anchor="middle" font-size="10" fill="#013a3b">Lowest cost</text>
+
+  <!-- ── Bottom note ── -->
+  <rect x="10" y="548" width="1180" height="26" rx="6" fill="#013a3b"/>
+  <text x="600" y="566" text-anchor="middle" font-size="12" font-weight="bold" fill="#d0fdf2">
+    Edera provides container-layer isolation — complementing all three data isolation strategies
+  </text>
+</svg>

--- a/slides/assets/road-to-multitenancy/deployment-architecture.svg
+++ b/slides/assets/road-to-multitenancy/deployment-architecture.svg
@@ -1,0 +1,125 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 580" font-family="sans-serif">
+  <!-- Background -->
+  <rect width="1200" height="580" fill="#d0fdf2"/>
+
+  <!-- Title -->
+  <text x="600" y="38" text-anchor="middle" font-size="22" font-weight="bold" fill="#013a3b">
+    Deployment Topology
+  </text>
+
+  <!-- ── Layer 1: External Traffic (top) ── -->
+  <rect x="380" y="55" width="440" height="50" rx="8" fill="#013a3b"/>
+  <text x="600" y="85" text-anchor="middle" font-size="15" font-weight="bold" fill="#d0fdf2">
+    Tenant Requests (Internet)
+  </text>
+
+  <!-- Arrow down -->
+  <line x1="600" y1="105" x2="600" y2="128" stroke="#013a3b" stroke-width="2"/>
+  <polygon points="592,126 608,126 600,140" fill="#013a3b"/>
+
+  <!-- ── Layer 2: Ingress / Load Balancer ── -->
+  <rect x="280" y="140" width="640" height="46" rx="8" fill="#013a3b" opacity="0.75"/>
+  <text x="600" y="168" text-anchor="middle" font-size="14" font-weight="bold" fill="#d0fdf2">
+    Kubernetes Ingress / Load Balancer
+  </text>
+
+  <!-- Arrows down to three nodes -->
+  <line x1="360" y1="186" x2="260" y2="218" stroke="#013a3b" stroke-width="2"/>
+  <polygon points="252,214 266,224 258,230" fill="#013a3b"/>
+  <line x1="600" y1="186" x2="600" y2="218" stroke="#013a3b" stroke-width="2"/>
+  <polygon points="592,216 608,216 600,230" fill="#013a3b"/>
+  <line x1="840" y1="186" x2="940" y2="218" stroke="#013a3b" stroke-width="2"/>
+  <polygon points="932,214 946,224 938,230" fill="#013a3b"/>
+
+  <!-- ── Worker Node Column A ── -->
+  <rect x="30" y="230" width="360" height="310" rx="10" fill="white" stroke="#013a3b" stroke-width="2"/>
+  <!-- Node header -->
+  <rect x="30" y="230" width="360" height="36" rx="10" fill="#013a3b"/>
+  <rect x="30" y="248" width="360" height="18" fill="#013a3b"/>
+  <text x="210" y="253" text-anchor="middle" font-size="14" font-weight="bold" fill="#d0fdf2">Worker Node 1</text>
+  <!-- Edera hypervisor -->
+  <rect x="42" y="274" width="336" height="24" rx="4" fill="#02f4d5"/>
+  <text x="210" y="290" text-anchor="middle" font-size="12" font-weight="bold" fill="#013a3b">Edera Hypervisor</text>
+  <!-- Zone 1A -->
+  <rect x="50" y="306" width="148" height="210" rx="6" fill="#c8fff5" stroke="#02f4d5" stroke-width="2"/>
+  <rect x="50" y="306" width="148" height="28" rx="6" fill="#013a3b"/>
+  <rect x="50" y="322" width="148" height="12" fill="#013a3b"/>
+  <text x="124" y="324" text-anchor="middle" font-size="12" font-weight="bold" fill="#02f4d5">Zone A</text>
+  <rect x="62" y="344" width="124" height="36" rx="4" fill="#013a3b"/>
+  <text x="124" y="366" text-anchor="middle" font-size="11" fill="#d0fdf2">Container</text>
+  <text x="124" y="402" text-anchor="middle" font-size="12" font-weight="bold" fill="#013a3b">Tenant A</text>
+  <rect x="62" y="418" width="124" height="20" rx="3" fill="#013a3b" opacity="0.15" stroke="#013a3b" stroke-width="1"/>
+  <text x="124" y="432" text-anchor="middle" font-size="10" fill="#013a3b">Dedicated Kernel</text>
+  <!-- Zone 1B -->
+  <rect x="212" y="306" width="148" height="210" rx="6" fill="#c8fff5" stroke="#02f4d5" stroke-width="2"/>
+  <rect x="212" y="306" width="148" height="28" rx="6" fill="#013a3b"/>
+  <rect x="212" y="322" width="148" height="12" fill="#013a3b"/>
+  <text x="286" y="324" text-anchor="middle" font-size="12" font-weight="bold" fill="#02f4d5">Zone B</text>
+  <rect x="224" y="344" width="124" height="36" rx="4" fill="#013a3b"/>
+  <text x="286" y="366" text-anchor="middle" font-size="11" fill="#d0fdf2">Container</text>
+  <text x="286" y="402" text-anchor="middle" font-size="12" font-weight="bold" fill="#013a3b">Tenant B</text>
+  <rect x="224" y="418" width="124" height="20" rx="3" fill="#013a3b" opacity="0.15" stroke="#013a3b" stroke-width="1"/>
+  <text x="286" y="432" text-anchor="middle" font-size="10" fill="#013a3b">Dedicated Kernel</text>
+
+  <!-- ── Worker Node Column B ── -->
+  <rect x="420" y="230" width="360" height="310" rx="10" fill="white" stroke="#013a3b" stroke-width="2"/>
+  <rect x="420" y="230" width="360" height="36" rx="10" fill="#013a3b"/>
+  <rect x="420" y="248" width="360" height="18" fill="#013a3b"/>
+  <text x="600" y="253" text-anchor="middle" font-size="14" font-weight="bold" fill="#d0fdf2">Worker Node 2</text>
+  <rect x="432" y="274" width="336" height="24" rx="4" fill="#02f4d5"/>
+  <text x="600" y="290" text-anchor="middle" font-size="12" font-weight="bold" fill="#013a3b">Edera Hypervisor</text>
+  <!-- Zone 2A -->
+  <rect x="440" y="306" width="148" height="210" rx="6" fill="#c8fff5" stroke="#02f4d5" stroke-width="2"/>
+  <rect x="440" y="306" width="148" height="28" rx="6" fill="#013a3b"/>
+  <rect x="440" y="322" width="148" height="12" fill="#013a3b"/>
+  <text x="514" y="324" text-anchor="middle" font-size="12" font-weight="bold" fill="#02f4d5">Zone C</text>
+  <rect x="452" y="344" width="124" height="36" rx="4" fill="#013a3b"/>
+  <text x="514" y="366" text-anchor="middle" font-size="11" fill="#d0fdf2">Container</text>
+  <text x="514" y="402" text-anchor="middle" font-size="12" font-weight="bold" fill="#013a3b">Tenant C</text>
+  <rect x="452" y="418" width="124" height="20" rx="3" fill="#013a3b" opacity="0.15" stroke="#013a3b" stroke-width="1"/>
+  <text x="514" y="432" text-anchor="middle" font-size="10" fill="#013a3b">Dedicated Kernel</text>
+  <!-- Zone 2B -->
+  <rect x="602" y="306" width="148" height="210" rx="6" fill="#c8fff5" stroke="#02f4d5" stroke-width="2"/>
+  <rect x="602" y="306" width="148" height="28" rx="6" fill="#013a3b"/>
+  <rect x="602" y="322" width="148" height="12" fill="#013a3b"/>
+  <text x="676" y="324" text-anchor="middle" font-size="12" font-weight="bold" fill="#02f4d5">Zone D</text>
+  <rect x="614" y="344" width="124" height="36" rx="4" fill="#013a3b"/>
+  <text x="676" y="366" text-anchor="middle" font-size="11" fill="#d0fdf2">Container</text>
+  <text x="676" y="402" text-anchor="middle" font-size="12" font-weight="bold" fill="#013a3b">Tenant D</text>
+  <rect x="614" y="418" width="124" height="20" rx="3" fill="#013a3b" opacity="0.15" stroke="#013a3b" stroke-width="1"/>
+  <text x="676" y="432" text-anchor="middle" font-size="10" fill="#013a3b">Dedicated Kernel</text>
+
+  <!-- ── Worker Node Column C ── -->
+  <rect x="810" y="230" width="360" height="310" rx="10" fill="white" stroke="#013a3b" stroke-width="2"/>
+  <rect x="810" y="230" width="360" height="36" rx="10" fill="#013a3b"/>
+  <rect x="810" y="248" width="360" height="18" fill="#013a3b"/>
+  <text x="990" y="253" text-anchor="middle" font-size="14" font-weight="bold" fill="#d0fdf2">Worker Node 3</text>
+  <rect x="822" y="274" width="336" height="24" rx="4" fill="#02f4d5"/>
+  <text x="990" y="290" text-anchor="middle" font-size="12" font-weight="bold" fill="#013a3b">Edera Hypervisor</text>
+  <!-- Zone 3A -->
+  <rect x="830" y="306" width="148" height="210" rx="6" fill="#c8fff5" stroke="#02f4d5" stroke-width="2"/>
+  <rect x="830" y="306" width="148" height="28" rx="6" fill="#013a3b"/>
+  <rect x="830" y="322" width="148" height="12" fill="#013a3b"/>
+  <text x="904" y="324" text-anchor="middle" font-size="12" font-weight="bold" fill="#02f4d5">Zone E</text>
+  <rect x="842" y="344" width="124" height="36" rx="4" fill="#013a3b"/>
+  <text x="904" y="366" text-anchor="middle" font-size="11" fill="#d0fdf2">Container</text>
+  <text x="904" y="402" text-anchor="middle" font-size="12" font-weight="bold" fill="#013a3b">Tenant E</text>
+  <rect x="842" y="418" width="124" height="20" rx="3" fill="#013a3b" opacity="0.15" stroke="#013a3b" stroke-width="1"/>
+  <text x="904" y="432" text-anchor="middle" font-size="10" fill="#013a3b">Dedicated Kernel</text>
+  <!-- Zone 3B -->
+  <rect x="992" y="306" width="148" height="210" rx="6" fill="#c8fff5" stroke="#02f4d5" stroke-width="2"/>
+  <rect x="992" y="306" width="148" height="28" rx="6" fill="#013a3b"/>
+  <rect x="992" y="322" width="148" height="12" fill="#013a3b"/>
+  <text x="1066" y="324" text-anchor="middle" font-size="12" font-weight="bold" fill="#02f4d5">Zone F</text>
+  <rect x="1004" y="344" width="124" height="36" rx="4" fill="#013a3b"/>
+  <text x="1066" y="366" text-anchor="middle" font-size="11" fill="#d0fdf2">Container</text>
+  <text x="1066" y="402" text-anchor="middle" font-size="12" font-weight="bold" fill="#013a3b">Tenant F</text>
+  <rect x="1004" y="418" width="124" height="20" rx="3" fill="#013a3b" opacity="0.15" stroke="#013a3b" stroke-width="1"/>
+  <text x="1066" y="432" text-anchor="middle" font-size="10" fill="#013a3b">Dedicated Kernel</text>
+
+  <!-- ── Cloud / Infrastructure bar (bottom) ── -->
+  <rect x="10" y="548" width="1180" height="26" rx="6" fill="#013a3b" opacity="0.75"/>
+  <text x="600" y="565" text-anchor="middle" font-size="12" font-weight="bold" fill="#d0fdf2">
+    Cloud Infrastructure (VMs / Bare Metal)  ·  Nodes scale horizontally as tenants grow
+  </text>
+</svg>

--- a/slides/assets/road-to-multitenancy/system-architecture-overview.svg
+++ b/slides/assets/road-to-multitenancy/system-architecture-overview.svg
@@ -1,0 +1,142 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 580" font-family="sans-serif">
+  <!-- Background -->
+  <rect width="1200" height="580" fill="#d0fdf2"/>
+
+  <!-- Kubernetes Cluster outer border -->
+  <rect x="10" y="10" width="1180" height="510" rx="12" fill="white"
+        stroke="#013a3b" stroke-width="3" stroke-dasharray="10,5"/>
+  <rect x="10" y="10" width="260" height="30" rx="6" fill="#013a3b"/>
+  <text x="140" y="30" text-anchor="middle" font-size="16" font-weight="bold"
+        fill="#d0fdf2">Kubernetes Cluster</text>
+
+  <!-- ── Control Plane ── -->
+  <rect x="25" y="50" width="175" height="455" rx="8" fill="#013a3b"/>
+  <text x="112" y="80" text-anchor="middle" font-size="15" font-weight="bold"
+        fill="#d0fdf2">Control Plane</text>
+  <!-- K8s wheel icon (simplified) -->
+  <circle cx="112" cy="140" r="38" fill="none" stroke="#02f4d5" stroke-width="3"/>
+  <circle cx="112" cy="140" r="10" fill="#02f4d5"/>
+  <line x1="112" y1="102" x2="112" y2="130" stroke="#02f4d5" stroke-width="3"/>
+  <line x1="112" y1="150" x2="112" y2="178" stroke="#02f4d5" stroke-width="3"/>
+  <line x1="74" y1="140" x2="102" y2="140" stroke="#02f4d5" stroke-width="3"/>
+  <line x1="122" y1="140" x2="150" y2="140" stroke="#02f4d5" stroke-width="3"/>
+  <line x1="84" y1="112" x2="104" y2="130" stroke="#02f4d5" stroke-width="3"/>
+  <line x1="120" y1="150" x2="140" y2="168" stroke="#02f4d5" stroke-width="3"/>
+  <line x1="140" y1="112" x2="120" y2="130" stroke="#02f4d5" stroke-width="3"/>
+  <line x1="104" y1="150" x2="84" y2="168" stroke="#02f4d5" stroke-width="3"/>
+
+  <text x="112" y="210" text-anchor="middle" font-size="12" fill="#d0fdf2">API Server</text>
+  <text x="112" y="232" text-anchor="middle" font-size="12" fill="#d0fdf2">Scheduler</text>
+  <text x="112" y="254" text-anchor="middle" font-size="12" fill="#d0fdf2">Controller Mgr</text>
+  <text x="112" y="276" text-anchor="middle" font-size="12" fill="#d0fdf2">etcd</text>
+
+  <!-- Connection line from control plane to worker nodes -->
+  <line x1="200" y1="275" x2="225" y2="275" stroke="#02f4d5" stroke-width="2" stroke-dasharray="5,3"/>
+
+  <!-- ── Worker Node 1 ── -->
+  <rect x="220" y="50" width="460" height="455" rx="8" fill="white" stroke="#013a3b" stroke-width="2"/>
+  <!-- Node header -->
+  <rect x="220" y="50" width="460" height="38" rx="8" fill="#013a3b"/>
+  <rect x="220" y="70" width="460" height="18" fill="#013a3b"/>
+  <text x="450" y="74" text-anchor="middle" font-size="15" font-weight="bold" fill="#d0fdf2">Worker Node 1</text>
+
+  <!-- Edera Hypervisor bar Node 1 -->
+  <rect x="232" y="98" width="436" height="26" rx="4" fill="#02f4d5"/>
+  <text x="450" y="115" text-anchor="middle" font-size="13" font-weight="bold"
+        fill="#013a3b">Edera Hypervisor (Type-1)</text>
+
+  <!-- Zone A -->
+  <rect x="240" y="132" width="200" height="195" rx="6" fill="#c8fff5" stroke="#02f4d5" stroke-width="2"/>
+  <rect x="240" y="132" width="200" height="30" rx="6" fill="#013a3b"/>
+  <rect x="240" y="150" width="200" height="12" fill="#013a3b"/>
+  <text x="340" y="152" text-anchor="middle" font-size="13" font-weight="bold" fill="#02f4d5">Zone A</text>
+  <!-- Container box -->
+  <rect x="258" y="172" width="164" height="52" rx="4" fill="#013a3b"/>
+  <text x="340" y="200" text-anchor="middle" font-size="12" fill="#d0fdf2">Container</text>
+  <text x="340" y="216" text-anchor="middle" font-size="10" fill="#d0fdf2">app workload</text>
+  <!-- Kernel label -->
+  <rect x="258" y="233" width="164" height="26" rx="4" fill="#013a3b" opacity="0.15" stroke="#013a3b" stroke-width="1"/>
+  <text x="340" y="249" text-anchor="middle" font-size="11" fill="#013a3b">Linux Kernel (dedicated)</text>
+  <text x="340" y="315" text-anchor="middle" font-size="13" font-weight="bold" fill="#013a3b">Tenant A</text>
+
+  <!-- Zone B -->
+  <rect x="458" y="132" width="200" height="195" rx="6" fill="#c8fff5" stroke="#02f4d5" stroke-width="2"/>
+  <rect x="458" y="132" width="200" height="30" rx="6" fill="#013a3b"/>
+  <rect x="458" y="150" width="200" height="12" fill="#013a3b"/>
+  <text x="558" y="152" text-anchor="middle" font-size="13" font-weight="bold" fill="#02f4d5">Zone B</text>
+  <rect x="476" y="172" width="164" height="52" rx="4" fill="#013a3b"/>
+  <text x="558" y="200" text-anchor="middle" font-size="12" fill="#d0fdf2">Container</text>
+  <text x="558" y="216" text-anchor="middle" font-size="10" fill="#d0fdf2">app workload</text>
+  <rect x="476" y="233" width="164" height="26" rx="4" fill="#013a3b" opacity="0.15" stroke="#013a3b" stroke-width="1"/>
+  <text x="558" y="249" text-anchor="middle" font-size="11" fill="#013a3b">Linux Kernel (dedicated)</text>
+  <text x="558" y="315" text-anchor="middle" font-size="13" font-weight="bold" fill="#013a3b">Tenant B</text>
+
+  <!-- Isolation arrow Node 1 -->
+  <line x1="452" y1="220" x2="452" y2="330" stroke="#013a3b" stroke-width="1.5" stroke-dasharray="4,3"/>
+  <text x="340" y="360" text-anchor="middle" font-size="10" fill="#013a3b" font-style="italic">no shared kernel</text>
+  <text x="558" y="360" text-anchor="middle" font-size="10" fill="#013a3b" font-style="italic">no shared kernel</text>
+
+  <!-- Host OS Node 1 -->
+  <rect x="232" y="380" width="436" height="28" rx="4" fill="#013a3b" opacity="0.55"/>
+  <text x="450" y="399" text-anchor="middle" font-size="12" fill="#d0fdf2">Host OS (Linux) · kubelet · CRI</text>
+
+  <!-- Connection line between nodes -->
+  <line x1="680" y1="275" x2="710" y2="275" stroke="#02f4d5" stroke-width="2" stroke-dasharray="5,3"/>
+
+  <!-- ── Worker Node 2 ── -->
+  <rect x="710" y="50" width="460" height="455" rx="8" fill="white" stroke="#013a3b" stroke-width="2"/>
+  <rect x="710" y="50" width="460" height="38" rx="8" fill="#013a3b"/>
+  <rect x="710" y="70" width="460" height="18" fill="#013a3b"/>
+  <text x="940" y="74" text-anchor="middle" font-size="15" font-weight="bold" fill="#d0fdf2">Worker Node 2</text>
+
+  <!-- Edera Hypervisor bar Node 2 -->
+  <rect x="722" y="98" width="436" height="26" rx="4" fill="#02f4d5"/>
+  <text x="940" y="115" text-anchor="middle" font-size="13" font-weight="bold"
+        fill="#013a3b">Edera Hypervisor (Type-1)</text>
+
+  <!-- Zone C -->
+  <rect x="730" y="132" width="200" height="195" rx="6" fill="#c8fff5" stroke="#02f4d5" stroke-width="2"/>
+  <rect x="730" y="132" width="200" height="30" rx="6" fill="#013a3b"/>
+  <rect x="730" y="150" width="200" height="12" fill="#013a3b"/>
+  <text x="830" y="152" text-anchor="middle" font-size="13" font-weight="bold" fill="#02f4d5">Zone C</text>
+  <rect x="748" y="172" width="164" height="52" rx="4" fill="#013a3b"/>
+  <text x="830" y="200" text-anchor="middle" font-size="12" fill="#d0fdf2">Container</text>
+  <text x="830" y="216" text-anchor="middle" font-size="10" fill="#d0fdf2">app workload</text>
+  <rect x="748" y="233" width="164" height="26" rx="4" fill="#013a3b" opacity="0.15" stroke="#013a3b" stroke-width="1"/>
+  <text x="830" y="249" text-anchor="middle" font-size="11" fill="#013a3b">Linux Kernel (dedicated)</text>
+  <text x="830" y="315" text-anchor="middle" font-size="13" font-weight="bold" fill="#013a3b">Tenant C</text>
+
+  <!-- Zone D -->
+  <rect x="948" y="132" width="200" height="195" rx="6" fill="#c8fff5" stroke="#02f4d5" stroke-width="2"/>
+  <rect x="948" y="132" width="200" height="30" rx="6" fill="#013a3b"/>
+  <rect x="948" y="150" width="200" height="12" fill="#013a3b"/>
+  <text x="1048" y="152" text-anchor="middle" font-size="13" font-weight="bold" fill="#02f4d5">Zone D</text>
+  <rect x="966" y="172" width="164" height="52" rx="4" fill="#013a3b"/>
+  <text x="1048" y="200" text-anchor="middle" font-size="12" fill="#d0fdf2">Container</text>
+  <text x="1048" y="216" text-anchor="middle" font-size="10" fill="#d0fdf2">app workload</text>
+  <rect x="966" y="233" width="164" height="26" rx="4" fill="#013a3b" opacity="0.15" stroke="#013a3b" stroke-width="1"/>
+  <text x="1048" y="249" text-anchor="middle" font-size="11" fill="#013a3b">Linux Kernel (dedicated)</text>
+  <text x="1048" y="315" text-anchor="middle" font-size="13" font-weight="bold" fill="#013a3b">Tenant D</text>
+
+  <!-- Isolation arrow Node 2 -->
+  <line x1="942" y1="220" x2="942" y2="330" stroke="#013a3b" stroke-width="1.5" stroke-dasharray="4,3"/>
+  <text x="830" y="360" text-anchor="middle" font-size="10" fill="#013a3b" font-style="italic">no shared kernel</text>
+  <text x="1048" y="360" text-anchor="middle" font-size="10" fill="#013a3b" font-style="italic">no shared kernel</text>
+
+  <!-- Host OS Node 2 -->
+  <rect x="722" y="380" width="436" height="28" rx="4" fill="#013a3b" opacity="0.55"/>
+  <text x="940" y="399" text-anchor="middle" font-size="12" fill="#d0fdf2">Host OS (Linux) · kubelet · CRI</text>
+
+  <!-- ── Footer caption ── -->
+  <text x="600" y="545" text-anchor="middle" font-size="14" fill="#013a3b">
+    Each Edera Zone has its own Linux kernel — tenants are fully isolated from each other
+  </text>
+
+  <!-- Legend -->
+  <rect x="20" y="530" width="14" height="14" rx="2" fill="#c8fff5" stroke="#02f4d5" stroke-width="1.5"/>
+  <text x="40" y="542" font-size="11" fill="#013a3b">Edera Zone (isolated lightweight VM)</text>
+  <rect x="250" y="530" width="14" height="14" rx="2" fill="#02f4d5"/>
+  <text x="270" y="542" font-size="11" fill="#013a3b">Edera Hypervisor</text>
+  <rect x="400" y="530" width="14" height="14" rx="2" fill="#013a3b"/>
+  <text x="420" y="542" font-size="11" fill="#013a3b">Kubernetes / Host OS</text>
+</svg>


### PR DESCRIPTION
## Summary

Adds three new SVG architecture diagrams to the Road to Multitenancy presentation,
providing visual anchors for the key concepts discussed in the talk. All diagrams
use the Edera V2 colour scheme and are placed at narrative-appropriate positions
in the slide deck.

## Changes Made

**New diagram files (`slides/assets/road-to-multitenancy/`):**
- `system-architecture-overview.svg` — Kubernetes cluster view showing the control
  plane, worker nodes, Edera Hypervisor layer, and isolated tenant zones (A–D)
- `deployment-architecture.svg` — Infrastructure topology showing tenant request
  routing from internet → ingress → worker nodes → Edera zones → containers
- `data-isolation-patterns.svg` — Three-column comparison of database-per-tenant,
  schema-per-tenant, and row-level security strategies with Edera context note

**Slide additions (`slides/2026-01-14-road-to-multitenancy.md`):**
- "Multi-Tenant System Architecture" slide — inserted after "How Edera Works" (slide 13)
- "Deployment Architecture" slide — follows System Architecture
- "Tenant Data Isolation Patterns" slide — inserted after "Platform Engineering Impact"

All new slides include comprehensive speaker notes.

## Motivation

Issue #78 requested three architecture diagrams to make complex multi-tenancy
concepts more accessible to the audience and provide reference material
post-presentation. The diagrams are created as SVG files to ensure:
- Crisp rendering at any resolution (vector format)
- Brand consistency (Edera V2 colours: `#013a3b`, `#d0fdf2`, `#02f4d5`)
- Version control as plain text
- Reliable rendering in both HTML and PDF output

## Testing

- [x] HTML build passes (`marp -I slides/ -o dist/`)
- [x] PDF build passes (`marp -I slides/ --pdf -o dist/`)
- [x] All smoke tests pass (16/16 checks)
- [x] SVG assets correctly copied to `dist/assets/road-to-multitenancy/`
- [x] All three SVG image references resolved in built HTML
- [x] Pre-commit hooks pass (9/9)

## Breaking Changes

None — existing slides are unchanged.

## Related Issues

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)