### PR TITLE
fix(gitignore): match node_modules symlinks in sibling worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,9 @@
 .env.development
 
 # Node.js
-node_modules/
+# No trailing slash: matches directories AND symlinks. Sibling worktrees
+# may contain a `node_modules` symlink which `node_modules/` would miss.
+node_modules
 npm-debug.log*
 
 # MARP build outputs


### PR DESCRIPTION
## Summary

- Drop trailing slash from `node_modules/` in `.gitignore` so the pattern matches directories, files, and symlinks.
- Unblocks `git worktree remove` during post-merge (`gc`) cleanup — sibling worktrees that contain a `node_modules` symlink to the primary worktree's `node_modules/` previously appeared as untracked content and refused removal.
- Add a 2-line comment explaining why the trailing slash was removed (non-obvious gitignore semantic).

## Verification

In the `gh-issue-098` worktree, created a `node_modules` symlink and confirmed:

- Before: `git status` → `?? node_modules`
- After: `git status` → clean; `git check-ignore -v node_modules` → matches `.gitignore:11`

## Test plan

- [x] Pre-commit hooks pass
- [x] Symlinked `node_modules` in a fresh worktree is ignored
- [ ] `git worktree remove <path>` succeeds without manual cleanup (verify post-merge)

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)