### PR TITLE
fix(slides): polish Beyond Containers pre-talk (#100)

### DIFF
--- a/docs/plan/issues/100_polish_items_beyond_containers.md
+++ b/docs/plan/issues/100_polish_items_beyond_containers.md
@@ -1,0 +1,112 @@
+---
+issue: 100
+title: Polish items for Beyond Containers (2026-04-14)
+status: Reviewed (Approved)
+branch: denhamparry.co.uk/fix/gh-issue-100
+---
+
+# Plan: Polish items for Beyond Containers talk
+
+Issue: denhamparry/talks#100
+
+## Scope
+
+Addresses items #1, #2, #4, #8, #9 from the review issue. These are the
+concrete, high-impact polish items that can be verified visually before the
+talk on 2026-04-14. Items #3, #5, #6, #7, #10 are deferred — they are either
+subjective, upstream (MARP), or low-value.
+
+## Changes
+
+### 1. Fix `two-columns` layout — `themes/edera-v2.css`
+
+**Problem:** `section.two-columns` uses `grid-template-columns: 1fr 1fr` but
+doesn't explicitly place children. CSS auto-places h2 → col 1, ul → col 2,
+next h2 → col 1, next ul → col 2 — producing a 2×2 stacked layout instead of
+side-by-side columns. Both h2 sub-sections end up in the same column pair,
+which defeats the comparison.
+
+**Fix:** Explicit grid placement so first `h2` + first content block land in
+column 1, second `h2` + second content block land in column 2. h1 spans both
+columns in row 1.
+
+```css
+section.two-columns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: auto auto 1fr;
+  column-gap: var(--spacing-lg);
+  row-gap: var(--spacing-sm);
+  align-items: start;
+}
+
+section.two-columns > h1 { grid-column: 1 / -1; grid-row: 1; }
+section.two-columns > h2:nth-of-type(1) { grid-column: 1; grid-row: 2; }
+section.two-columns > h2:nth-of-type(2) { grid-column: 2; grid-row: 2; }
+section.two-columns > ul:nth-of-type(1),
+section.two-columns > ol:nth-of-type(1),
+section.two-columns > p:nth-of-type(1),
+section.two-columns > pre:nth-of-type(1) { grid-column: 1; grid-row: 3; }
+section.two-columns > ul:nth-of-type(2),
+section.two-columns > ol:nth-of-type(2),
+section.two-columns > p:nth-of-type(2),
+section.two-columns > pre:nth-of-type(2) { grid-column: 2; grid-row: 3; }
+```
+
+Verified that the two-column template (`templates/layouts/two-column.md`)
+covers all three shapes: ul+ul, ul+ul, pre+ul. `pre` added for the code
+example.
+
+### 2. Title slide logo + footer — `slides/2026-04-14-beyond-containers.md`
+
+**Problem (#2):** inline Edera PNG has an opaque white background that clashes
+with the dark teal title slide.
+
+**Problem (#4):** title slide repeats the meetup/date in both the slide body
+and the MARP footer.
+
+**Fix:** remove the inline `<img>` block and suppress the footer on the title
+slide using Marp's `_footer: ''` directive.
+
+### 3. Clean up speaker notes — `slides/2026-04-14-beyond-containers.md`
+
+Remove obsolete `HOLDING IMAGE: refine or replace before the talk` lines at
+markdown lines 147, 284, and 432 — the diagrams have been produced.
+
+Also remove the leftover `Update [Event Name] placeholder before the talk`
+line at 28 — the event is set.
+
+### 4. CVE table row tweak — `slides/2026-04-14-beyond-containers.md`
+
+Shorten CVE-2026-5747 Impact cell to reduce wrapping:
+`Guest root → host VMM OOB write (potential RCE)`
+
+## Files Modified
+
+- `themes/edera-v2.css`
+- `slides/2026-04-14-beyond-containers.md`
+- `docs/plan/issues/100_polish_items_beyond_containers.md` (this file)
+
+## Verification
+
+1. `npm run build` — build succeeds, no errors
+2. Open `dist/2026-04-14-beyond-containers.html` in a browser, navigate to:
+   - Slide 4 (Namespaces ≠ Isolation) — h2s side-by-side, bullets under each
+   - Slide 12 (Shared Kernel vs MicroVM) — same shape
+   - Slide 1 (title) — no logo frame, no duplicate footer
+   - Slide 7 (CVE table) — last row reads on one line
+3. `make test-smoke` — smoke tests pass
+4. `pre-commit run --all-files`
+
+## Self-review
+
+- Risk: two-columns CSS change may affect `security-in-cloud-native-landscape`
+  or any other deck using the class. Mitigation: change is a structural
+  improvement; existing decks following the h2+content pattern will benefit
+  from the fix. No slide today relies on the current (broken) auto-flow order.
+- Risk: `_footer: ''` is slide-scoped in MARP — verified syntactically
+  correct.
+- Risk: removing the title-slide logo reduces branding on the opening frame.
+  Mitigation: presenter says "Lewis from Edera" in the opening hook; the
+  URL `Edera.dev` is still visible. The header badge appears on every content
+  slide.

--- a/slides/2026-04-14-beyond-containers.md
+++ b/slides/2026-04-14-beyond-containers.md
@@ -6,6 +6,7 @@ footer: 'April 14th, 2026 [Cloud Native and Kubernetes Edinburgh](https://www.me
 ---
 
 <!-- _class: title -->
+<!-- _footer: '' -->
 
 # Beyond Containers
 
@@ -14,10 +15,6 @@ footer: 'April 14th, 2026 [Cloud Native and Kubernetes Edinburgh](https://www.me
 Lewis Denham-Parry | [Edera.dev](https://edera.dev)
 [Cloud Native and Kubernetes Edinburgh](https://www.meetup.com/cloud-native-kubernetes-edinburgh/events/313744012/) | April 14th, 2026
 
-<div style="text-align: center; margin-top: 1.5rem;">
-  <img src="./assets/ederav2/edera-logo.png" alt="Edera" style="width: 180px;">
-</div>
-
 <!--
 Speaker Notes:
 - Welcome the room, introduce yourself briefly: Lewis from Edera
@@ -25,7 +22,6 @@ Speaker Notes:
   almost certainly running a shared kernel — and that has consequences
 - Format: 25 minutes + 5 minutes Q&A
 - Two live demos: encourage questions at the end to keep pacing tight
-- Update [Event Name] placeholder before the talk
 -->
 
 ---
@@ -143,9 +139,8 @@ Speaker Notes:
 - Every container arrow lands on the same kernel block
 - That block is the only thing between tenants and the hardware
 - One CVE in that block = every tenant above is exposed
-- HOLDING IMAGE: refine before the talk if there's time, or replace
-  with a cleaner version — the structure is the point
 -->
+
 
 ---
 
@@ -161,7 +156,7 @@ Speaker Notes:
 | **CVE-2025-31133** | 2025 | runc | Masked-path race condition |
 | **CVE-2025-52565** | 2025 | runc | `/dev/console` mount escape |
 | **CVE-2025-38617** | 2025 | Linux kernel | Packet socket use-after-free |
-| **CVE-2026-5747** | 2026 | Firecracker virtio-pci | Guest root → OOB write in host VMM process (potential RCE) |
+| **CVE-2026-5747** | 2026 | Firecracker virtio-pci | Guest root → host VMM OOB write (potential RCE) |
 
 > One kernel. ~40M lines of C. ~450 syscalls. One bug reaches every tenant.
 
@@ -281,7 +276,6 @@ Speaker Notes:
 - Mirror image of the "Shape of the Problem" diagram
 - Each zone has its own kernel — call out the vertical stack per zone
 - Hypervisor is the only shared block, and it's tiny compared to Linux
-- HOLDING IMAGE: refine or replace before the talk
 -->
 
 ---
@@ -429,7 +423,6 @@ Speaker Notes:
 - Left side: same attack, reaches every tenant on the node
 - Right side: same attack, contained to the attacker's zone
 - The architecture is the difference, not the workload
-- HOLDING IMAGE: refine or replace before the talk
 -->
 
 ---

--- a/themes/edera-v2.css
+++ b/themes/edera-v2.css
@@ -418,12 +418,44 @@ section.light {
 section.two-columns {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: var(--spacing-lg);
+  grid-template-rows: auto auto 1fr;
+  column-gap: var(--spacing-lg);
+  row-gap: var(--spacing-sm);
   align-items: start;
 }
 
-section.two-columns h1 {
+/* h1 spans both columns on the first row */
+section.two-columns > h1 {
   grid-column: 1 / -1;
+  grid-row: 1;
+}
+
+/* First h2 heads column 1, second h2 heads column 2 (both on row 2) */
+section.two-columns > h2:nth-of-type(1) {
+  grid-column: 1;
+  grid-row: 2;
+}
+section.two-columns > h2:nth-of-type(2) {
+  grid-column: 2;
+  grid-row: 2;
+}
+
+/* First content block (ul/ol/p/pre) sits under the first h2 */
+section.two-columns > ul:nth-of-type(1),
+section.two-columns > ol:nth-of-type(1),
+section.two-columns > p:nth-of-type(1),
+section.two-columns > pre:nth-of-type(1) {
+  grid-column: 1;
+  grid-row: 3;
+}
+
+/* Second content block sits under the second h2 */
+section.two-columns > ul:nth-of-type(2),
+section.two-columns > ol:nth-of-type(2),
+section.two-columns > p:nth-of-type(2),
+section.two-columns > pre:nth-of-type(2) {
+  grid-column: 2;
+  grid-row: 3;
 }
 
 /* Image Slide */


### PR DESCRIPTION
## Summary

Addresses the high/medium items from #100 before the 2026-04-14 talk:

- **`themes/edera-v2.css` — `two-columns` layout fix.** Previously CSS grid auto-placed each `h2` in column 1 and each `ul` in column 2, producing a stacked 2×2 that defeated the comparison. Now the first `h2` + its content land in column 1, second in column 2, with `h1` spanning both. Before/after screenshots attached to the issue.
- **Title slide cleanup.** Removed the inline Edera PNG (opaque white background clashed with dark teal) and suppressed the duplicated footer on the title slide via `_footer: ''`.
- **CVE-2026-5747 row wrap.** Shortened the Impact cell so the last row fits on one line.
- **Speaker-note housekeeping.** Removed stale `HOLDING IMAGE` and `[Event Name]` placeholders now that diagrams and meetup details are finalised.

Deferred items from #100 (not blocking the talk): #3 header badge padding, #5 final-slide hierarchy, #6 emoji list, #7 upstream MARP meta, #10 footer link underline. These are subjective/low-impact — leaving them for a post-talk polish pass.

## Test plan

- [x] `npm run build` succeeds
- [x] `npm run test:smoke` passes (17 checks)
- [x] `pre-commit run --all-files` passes
- [x] Visual verification via Playwright — slides #1, #4, #7, #12 render as intended
- [ ] Reviewer: click through all 20 slides at talks.denhamparry.co.uk once the PR is deployed

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)