### PR TITLE
feat(build): add non-blocking CHANGELOG reminder hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,3 +36,13 @@ repos:
     hooks:
       - id: markdownlint-cli2
         name: Lint Markdown files
+
+  # Local hooks
+  - repo: local
+    hooks:
+      - id: check-changelog
+        name: Warn when build files change without CHANGELOG update
+        entry: scripts/check-changelog.sh
+        language: script
+        pass_filenames: false
+        stages: [pre-commit]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- CHANGELOG reminder hook: new `scripts/check-changelog.sh` pre-commit hook
+  warns (non-blocking) when build-system files change without a `CHANGELOG.md`
+  update ([#103](https://github.com/denhamparry/talks/issues/103))
+- `fix-meta-tags` build step: `scripts/fix-meta-tags.js` now runs after
+  favicon generation to inject the modern `mobile-web-app-capable` meta tag
+  alongside MARP's legacy `apple-mobile-web-app-capable`
+  ([#102](https://github.com/denhamparry/talks/issues/102))
+  - Updated build chain:
+    `marp → copy-assets → generate-index → generate-favicon → fix-meta-tags`
+
+### Documentation
+
+- Added "Changelog convention" guidance to `CLAUDE.md` describing when an
+  `[Unreleased]` entry is expected
+
 ## [1.0.4] - 2025-12-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - CHANGELOG reminder hook: new `scripts/check-changelog.sh` pre-commit hook
-  warns (non-blocking) when build-system files change without a `CHANGELOG.md`
-  update ([#103](https://github.com/denhamparry/talks/issues/103))
+  warns (non-blocking) when build-system files are staged without a
+  `CHANGELOG.md` update in the same commit
+  ([#103](https://github.com/denhamparry/talks/issues/103))
 - `fix-meta-tags` build step: `scripts/fix-meta-tags.js` now runs after
   favicon generation to inject the modern `mobile-web-app-capable` meta tag
   alongside MARP's legacy `apple-mobile-web-app-capable`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,9 +166,10 @@ build or runtime surface of the project. The pre-commit hook
 `scripts/check-changelog.sh` prints a (non-blocking) warning when staged
 changes touch build-system files without a `CHANGELOG.md` update.
 
-**Changes that SHOULD get a CHANGELOG entry:**
+**Changes that SHOULD get a CHANGELOG entry** (matches the hook's trigger
+patterns):
 
-- `package.json` scripts (build chain additions/removals, new tooling)
+- `package.json` and `package-lock.json` (build chain, tooling, dependencies)
 - New or modified files under `scripts/` that affect build output
 - `Dockerfile`, `docker-compose.yml`, `nginx.conf`
 - Theme changes under `themes/` visible in rendered output

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,6 +159,31 @@ Use `make` commands for consistency across projects. Use npm scripts directly if
 - Always create PR for review
 - Rebase before merging
 
+## Changelog Convention
+
+Add an entry under `CHANGELOG.md` `[Unreleased]` when a commit changes the
+build or runtime surface of the project. The pre-commit hook
+`scripts/check-changelog.sh` prints a (non-blocking) warning when staged
+changes touch build-system files without a `CHANGELOG.md` update.
+
+**Changes that SHOULD get a CHANGELOG entry:**
+
+- `package.json` scripts (build chain additions/removals, new tooling)
+- New or modified files under `scripts/` that affect build output
+- `Dockerfile`, `docker-compose.yml`, `nginx.conf`
+- Theme changes under `themes/` visible in rendered output
+- `.github/workflows/` changes affecting CI behaviour users depend on
+
+**Changes that can skip CHANGELOG:**
+
+- Slide content edits under `slides/`
+- Pure refactors, typo fixes, dev-only tweaks
+- Plan documents under `docs/plan/`
+
+Follow the existing [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+sections (`Added` / `Changed` / `Fixed` / `Documentation`). Reference the
+issue number where available.
+
 ## Pre-commit Hooks
 
 This template includes `.pre-commit-config.yaml` with generic code quality hooks:

--- a/docs/plan/issues/103_changelog_entry_workflow_for_slide_polish.md
+++ b/docs/plan/issues/103_changelog_entry_workflow_for_slide_polish.md
@@ -1,0 +1,85 @@
+---
+issue: 103
+title: "enhancement: add CHANGELOG entry workflow for slide polish changes"
+status: Planning
+---
+
+# Plan: CHANGELOG entry workflow for build-system / slide polish changes
+
+## Problem
+
+The repo's `CHANGELOG.md` documents the build chain (line 51:
+`marp → copy-assets → generate-index → generate-favicon`) but this is now stale.
+Issue #102 added a new build step `fix-meta-tags` (see `package.json` line 14-15)
+and updated the build chain, yet `CHANGELOG.md` was never updated. There is no
+mechanism that reminds contributors to update `CHANGELOG.md` when
+build-system-relevant files change.
+
+Issue #103 proposes either:
+
+1. Require CHANGELOG updates whenever `package.json` build scripts change, **or**
+2. Auto-generate a CHANGELOG diff section from conventional-commit messages.
+
+We will implement **option 1** (a lightweight pre-commit warning hook). Option 2
+is heavier and better left to a release-time tool like `git-cliff` — out of
+scope for a nice-to-have.
+
+## Approach
+
+Three focused changes:
+
+1. **`scripts/check-changelog.sh`** — a local pre-commit hook script. When
+   staged changes touch build-system files (`package.json` scripts section,
+   `scripts/*.js`, `Dockerfile`, `nginx.conf`, `docker-compose.yml`), the hook
+   checks that `CHANGELOG.md` is also staged. If not, it prints a warning and
+   exits **0** (non-blocking reminder — does not fail the commit). Rationale:
+   solo-maintainer repo; a hard block would be annoying for trivial refactors.
+   The warning is enough to trigger memory.
+
+2. **`.pre-commit-config.yaml`** — register the script as a `local` hook so it
+   runs alongside the existing hooks on every commit.
+
+3. **`CHANGELOG.md`** — add an `[Unreleased]` section populating the missing
+   entries (at minimum the `fix-meta-tags` build step from #102). Keeps the
+   changelog honest from this point forward without rewriting history.
+
+4. **`CLAUDE.md`** — add a short "Changelog convention" section under the
+   project instructions so Claude Code (and humans) know when a CHANGELOG entry
+   is required.
+
+## Files Modified
+
+- `scripts/check-changelog.sh` (new)
+- `.pre-commit-config.yaml`
+- `CHANGELOG.md`
+- `CLAUDE.md`
+
+## Implementation Tasks
+
+1. Write `scripts/check-changelog.sh` with the "staged build files imply staged
+   CHANGELOG" check. Use `git diff --cached --name-only` so it only considers
+   the current commit's staged files. Make it executable.
+2. Add a `local` hook entry to `.pre-commit-config.yaml` pointing at the script,
+   with `stages: [pre-commit]` and `pass_filenames: false`.
+3. Update `CHANGELOG.md` `[Unreleased]` section with an entry documenting the
+   `fix-meta-tags` build step and the new check-changelog tooling.
+4. Add a "Changelog convention" section to `CLAUDE.md` (under Git Workflow).
+5. Run pre-commit locally and confirm the new hook runs and the existing hooks
+   still pass.
+
+## Acceptance Criteria
+
+- [ ] `scripts/check-changelog.sh` exists and is executable.
+- [ ] Pre-commit runs the new hook alongside the existing hooks.
+- [ ] Modifying `package.json` without touching `CHANGELOG.md` produces a
+      visible warning (but does not block the commit).
+- [ ] `CHANGELOG.md` `[Unreleased]` section lists the `fix-meta-tags` addition.
+- [ ] `CLAUDE.md` documents when a CHANGELOG entry is expected.
+- [ ] All pre-commit hooks pass.
+
+## Non-goals
+
+- Auto-generating CHANGELOG entries from commit messages (suggested option 2).
+- Blocking commits hard on CHANGELOG absence (friction too high for a solo
+  repo).
+- Backfilling every missing CHANGELOG entry since v1.0.4.

--- a/scripts/check-changelog.sh
+++ b/scripts/check-changelog.sh
@@ -9,18 +9,28 @@
 set -euo pipefail
 
 # Files whose changes typically warrant a CHANGELOG entry.
+# Leaf-name patterns are anchored with `(^|/)...$` so `package.json` does not
+# match `slides/assets/some-package.json`. Directory patterns use `^dir/`.
 build_patterns=(
-  'package.json'
-  'package-lock.json'
+  '(^|/)package\.json$'
+  '(^|/)package-lock\.json$'
   '^scripts/'
-  'Dockerfile'
-  'docker-compose\.yml'
-  'nginx\.conf'
+  '(^|/)Dockerfile$'
+  '(^|/)docker-compose\.yml$'
+  '(^|/)nginx\.conf$'
   '^themes/'
   '^\.github/workflows/'
 )
 
-staged=$(git diff --cached --name-only --diff-filter=ACMR)
+# Non-blocking contract: if `git diff` itself fails (corrupt index, detached
+# state, etc.) we must NOT abort with set -e exit 1 — that would block the
+# commit. Swallow the failure and exit 0 with a diagnostic instead. We also
+# drop --diff-filter so deletions (D) of build files are detected too — removing
+# a workflow or script is a build-surface change worth a CHANGELOG entry.
+staged=$(git diff --cached --name-only 2>/dev/null) || {
+  echo "check-changelog: skipping (git diff failed)" >&2
+  exit 0
+}
 if [ -z "$staged" ]; then
   exit 0
 fi

--- a/scripts/check-changelog.sh
+++ b/scripts/check-changelog.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Warn (do not block) when build-system files change without a CHANGELOG update.
+#
+# Rationale: keeps CHANGELOG.md in sync with build-chain changes (see #103).
+# The hook is deliberately non-blocking — a hard block would punish trivial
+# refactors in a solo-maintainer repo. The visible warning is enough to jog
+# memory for entries that actually matter.
+
+set -euo pipefail
+
+# Files whose changes typically warrant a CHANGELOG entry.
+build_patterns=(
+  'package.json'
+  'package-lock.json'
+  '^scripts/'
+  'Dockerfile'
+  'docker-compose\.yml'
+  'nginx\.conf'
+  '^themes/'
+  '^\.github/workflows/'
+)
+
+staged=$(git diff --cached --name-only --diff-filter=ACMR)
+if [ -z "$staged" ]; then
+  exit 0
+fi
+
+build_changed=0
+for pattern in "${build_patterns[@]}"; do
+  if printf '%s\n' "$staged" | grep -Eq "$pattern"; then
+    build_changed=1
+    break
+  fi
+done
+
+if [ "$build_changed" -eq 0 ]; then
+  exit 0
+fi
+
+if printf '%s\n' "$staged" | grep -qx 'CHANGELOG.md'; then
+  exit 0
+fi
+
+cat >&2 <<'EOF'
+⚠️  check-changelog: build-system files are staged but CHANGELOG.md is not.
+
+Consider adding an entry under [Unreleased] in CHANGELOG.md describing the
+change. If this commit genuinely does not need a CHANGELOG entry (e.g. pure
+refactor, typo fix, CI-only tweak), you can ignore this warning.
+
+This hook does not block the commit.
+EOF
+
+exit 0


### PR DESCRIPTION
## Summary

- New `scripts/check-changelog.sh` pre-commit hook warns (exit 0, non-blocking) when build-system files are staged without a `CHANGELOG.md` update. Targets `package.json`, `scripts/`, `Dockerfile`, `docker-compose.yml`, `nginx.conf`, `themes/`, `.github/workflows/`.
- Populates `[Unreleased]` in `CHANGELOG.md` with the `fix-meta-tags` build step that was missed by #102, plus this hook itself.
- Documents the changelog convention in `CLAUDE.md` (when an entry is expected vs. when it can be skipped).

Implements the first of the two options suggested in #103 (per-commit reminder). Option 2 (auto-generating from conventional commits) is deferred as a release-time concern.

## Test plan

- [x] Pre-commit hooks pass locally (including the new hook)
- [x] Hook emits warning when build file staged without CHANGELOG.md (simulated)
- [x] Hook exits 0 in both warning and clean paths (non-blocking)
- [ ] CI pre-commit workflow passes

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)