### PR TITLE
fix(index): sort talks by date, newest first

### DIFF
--- a/docs/plan/issues/108_order_talks_by_date.md
+++ b/docs/plan/issues/108_order_talks_by_date.md
@@ -1,0 +1,85 @@
+# Plan: Order talks by date (newest first) on index page
+
+**Issue:** #108
+**Status:** Reviewed (Approved)
+**Type:** Bug fix
+
+## Problem
+
+The index page at `https://talks.denhamparry.co.uk/` sorts presentations
+alphabetically by their human-readable footer date string (e.g., "April" <
+"December" < "January") instead of chronologically. The sort in
+`scripts/generate-index.js:117` uses `b.date.localeCompare(a.date)` where
+`date` is the full footer string.
+
+## Solution
+
+Add a `sortDate` field to each presentation metadata object, extracted from the
+`YYYY-MM-DD` prefix in the filename. Use `sortDate` for sorting (ISO dates sort
+correctly as strings) and keep the existing `date` field for display.
+
+Talks without a date in the filename sort to the bottom (empty string sorts
+last in descending order when handled explicitly).
+
+## Implementation Tasks
+
+### Task 1: Add `sortDate` field to `extractMetadata` return value
+
+**File:** `scripts/generate-index.js`
+**Lines:** ~84–96
+
+Extract the ISO date from the filename and return it as a separate `sortDate`
+field alongside the existing `date` (display) field.
+
+```javascript
+const dateMatch = path.basename(filePath).match(/^(\d{4}-\d{2}-\d{2})/);
+const sortDate = dateMatch ? dateMatch[1] : '';
+```
+
+Add `sortDate` to the returned object.
+
+### Task 2: Update sort comparator to use `sortDate`
+
+**File:** `scripts/generate-index.js`
+**Line:** 117
+
+Change:
+
+```javascript
+.sort((a, b) => b.date.localeCompare(a.date));
+```
+
+To:
+
+```javascript
+.sort((a, b) => b.sortDate.localeCompare(a.sortDate));
+```
+
+This ensures ISO date string comparison (`2026-04-14` > `2026-01-14` >
+`2025-12-04`), which is chronologically correct.
+
+### Task 3: Verify with build and smoke test
+
+Run `npm run build` and `npm run test:smoke` to confirm the index generates
+correctly with the new ordering.
+
+## Files Modified
+
+- `scripts/generate-index.js`
+
+## Expected Result
+
+Index page order (newest first):
+
+1. Beyond Containers (April 14th, 2026)
+2. The Road to Multitenancy (January 14th, 2026)
+3. What I wish I knew about AI... (December 4th, 2025)
+4. Security in Cloud Native Landscape (no date — sorts to bottom)
+
+## Acceptance Criteria
+
+- [ ] Talks with ISO dates in filenames sort newest-first
+- [ ] Talks without dates in filenames appear at the bottom
+- [ ] Display dates (footer strings) remain unchanged
+- [ ] `npm run build` succeeds
+- [ ] `npm run test:smoke` passes

--- a/docs/plan/issues/108_order_talks_by_date.md
+++ b/docs/plan/issues/108_order_talks_by_date.md
@@ -1,7 +1,7 @@
 # Plan: Order talks by date (newest first) on index page
 
 **Issue:** #108
-**Status:** Reviewed (Approved)
+**Status:** Complete
 **Type:** Bug fix
 
 ## Problem

--- a/scripts/generate-index.js
+++ b/scripts/generate-index.js
@@ -77,19 +77,21 @@ function extractMetadata(filePath) {
     title = path.basename(filePath, '.md');
   }
 
-  // Use footer for date if available, otherwise extract from filename (format: YYYY-MM-DD-*)
+  // Extract ISO date from filename for sorting (YYYY-MM-DD prefix)
+  const dateMatch = path.basename(filePath).match(/^(\d{4}-\d{2}-\d{2})/);
+  const sortDate = dateMatch ? dateMatch[1] : '';
+
+  // Use footer for display date if available, otherwise fall back to ISO date
   if (footer) {
     date = footer;
-  } else {
-    const dateMatch = path.basename(filePath).match(/^(\d{4}-\d{2}-\d{2})/);
-    if (dateMatch) {
-      date = dateMatch[1];
-    }
+  } else if (sortDate) {
+    date = sortDate;
   }
 
   return {
     title,
     date,
+    sortDate,
     header,
     htmlFile: path.basename(filePath, '.md') + '.html',
     unlisted
@@ -114,7 +116,7 @@ function generateIndex() {
   // Extract metadata from each file
   const presentations = files.map(extractMetadata)
     .filter(p => !p.unlisted) // Filter out unlisted presentations
-    .sort((a, b) => b.date.localeCompare(a.date)); // Sort by date descending
+    .sort((a, b) => b.sortDate.localeCompare(a.sortDate)); // Sort by ISO date descending
 
   // Generate HTML
   const html = `<!DOCTYPE html>


### PR DESCRIPTION
## Summary

- Sort index page presentations by ISO date extracted from filename (`YYYY-MM-DD` prefix) instead of the human-readable footer string
- Adds a `sortDate` field to presentation metadata, keeping the display `date` unchanged
- Fixes alphabetical month-name ordering ("April" < "December" < "January") that produced incorrect chronological order

## Test plan

- [x] `npm run build` succeeds
- [x] `npm run test:smoke` passes
- [x] Index order verified: Beyond Containers (2026-04-14) → Road to Multitenancy (2026-01-14) → Cloud Native Manchester (2025-12-04)
- [x] Talks without ISO date in filename sort to bottom
- [x] Display dates (footer strings) unchanged

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)