### PR TITLE
fix(slides): expand CVE-2026-5747 speaker notes on Beyond Containers slide 7

### DIFF
--- a/docs/plan/issues/110_expand_cve_2026_5747_speaker_notes.md
+++ b/docs/plan/issues/110_expand_cve_2026_5747_speaker_notes.md
@@ -2,7 +2,7 @@
 
 **Issue:** #110 — Expand speaker notes for CVE-2026-5747 on slide 7 (Beyond
 Containers)
-**Status:** Reviewed (Approved)
+**Status:** Complete
 **Type:** fix (content)
 
 ## Context

--- a/docs/plan/issues/110_expand_cve_2026_5747_speaker_notes.md
+++ b/docs/plan/issues/110_expand_cve_2026_5747_speaker_notes.md
@@ -1,0 +1,78 @@
+# Plan: Expand Speaker Notes for CVE-2026-5747 on Slide 7
+
+**Issue:** #110 — Expand speaker notes for CVE-2026-5747 on slide 7 (Beyond
+Containers)
+**Status:** Reviewed (Approved)
+**Type:** fix (content)
+
+## Context
+
+Slide 7 ("This Isn't Theoretical — Recent CVEs") in
+`slides/2026-04-14-beyond-containers.md` has compressed speaker notes covering
+CVE-2026-5747. The speaker wants fuller, narrative-ready notes for two key
+talking points so they can speak from them naturally without reading CVE IDs from
+the slide.
+
+## Scope
+
+- **Single file change:** `slides/2026-04-14-beyond-containers.md`
+- **Lines affected:** 163–182 (the `<!-- Speaker Notes: ... -->` block for
+  slide 7)
+- **No changes to slide content** (table, heading, footer quote remain
+  untouched)
+
+## Implementation Tasks
+
+### Task 1: Expand CVE-2026-5747 VMM-layer talking point
+
+Replace the current compressed bullet (lines 173–177) with a fuller narrative
+block that covers:
+
+- What the bug is: OOB write in Firecracker's virtio-pci transport, guest root
+  can write past bounds into host VMM process memory
+- Why it matters for the talk's argument: the class of shared-resource bug isn't
+  confined to kernel + runtime + GPU toolkit — it appears in the VMM layer too
+- The disclosure context: reported by Anthropic via AWS VDP, disclosed
+  2026-04-07
+- The architectural lesson: even microVM sandboxes have host-userspace attack
+  surface; the argument is about where bugs land (blast radius), not whether
+  they exist
+
+### Task 2: Expand cadence-over-memorisation talking point
+
+Replace the current one-liner (lines 178–179) with speaker-ready notes that
+help land the message:
+
+- Don't read CVE numbers from the slide — gesture at the table
+- The point is the pattern: every few months, another shared-resource escape
+- Frame it as "this is the new normal" — not a one-off, but a recurring class
+- This sets up the second half of the talk (microVM solution)
+
+### Task 3: Preserve source attributions and pacing
+
+Keep the existing source references and time check intact:
+
+- Source: Beganović, "Your Container Is Not a Sandbox" (March 2026)
+- CVE-2026-5747 via GHSA-776c-mpj7-jm3r / AWS-2026-015
+- Time check: ~7 minutes in
+
+### Task 4: Verify build
+
+Run `make build` to confirm the change doesn't break the MARP build.
+
+## Files Modified
+
+- `slides/2026-04-14-beyond-containers.md` (speaker notes only, lines 163–182)
+
+## Acceptance Criteria
+
+- [ ] Speaker notes for slide 7 expanded with narrative detail for both sections
+- [ ] Notes remain in `<!-- Speaker Notes: ... -->` HTML comment format
+- [ ] No changes to slide content (table, heading, footer quote)
+- [ ] Build passes (`make build`)
+
+## Risk Assessment
+
+- **Low risk** — changes are inside HTML comments (invisible to rendered slides)
+- **No functional impact** — speaker notes don't affect build output
+- **Build verification** is the only gate needed

--- a/slides/2026-04-14-beyond-containers.md
+++ b/slides/2026-04-14-beyond-containers.md
@@ -172,8 +172,8 @@ Speaker Notes:
   toolkit bug needed
 
 [CVE-2026-5747 — VMM layer widens the point]
-- Now bring in the newest row on the table. CVE-2026-5747 dropped a week
-  ago — 7th April — and it's not a kernel bug, not a runtime bug, not a
+- Now bring in the newest row on the table. CVE-2026-5747 was disclosed
+  on 7 April 2026 — and it's not a kernel bug, not a runtime bug, not a
   GPU toolkit bug. It's in Firecracker's virtio-pci transport: the device
   model that sits between a guest VM and the host.
 - What happens: a guest with root can craft a malicious PCI config write
@@ -189,16 +189,15 @@ Speaker Notes:
   no bugs." It's about where bugs land. A VMM bug in Firecracker affects
   the host-userspace process for one workload. A kernel bug affects every
   tenant on the node. Blast radius is the difference.
-- Disclosure context: reported by Anthropic's security team via AWS's
-  Vulnerability Disclosure Program. Anthropic runs Firecracker at scale
-  for their AI workloads — they found this in production-grade usage.
-  Fix shipped in Firecracker 1.14.4 / 1.15.1 for anyone running
-  --enable-pci.
+- Disclosure context: reported by Anthropic via AWS's Vulnerability
+  Disclosure Program (verify Anthropic attribution appears in
+  GHSA-776c-mpj7-jm3r before delivery). Fix shipped in Firecracker
+  1.14.4 / 1.15.1 for anyone running --enable-pci.
 
 [Cadence over memorisation — land the pattern]
 - Don't read CVE numbers off the slide. Gesture at the table and make
   the point about the pattern: "Look at the dates. 2024, 2024, 2025,
-  2025, 2025, 2025, 2026. Every few months, another shared-resource
+  2025, 2025, 2025, 2026. Roughly every quarter, another shared-resource
   escape. Different component each time — runtime, kernel, GPU toolkit,
   VMM — but the same class of bug."
 - The message to land clearly: this is not a one-off. This is the new

--- a/slides/2026-04-14-beyond-containers.md
+++ b/slides/2026-04-14-beyond-containers.md
@@ -170,13 +170,47 @@ Speaker Notes:
   for the AI/ML crowd in the room
 - CVE-2025-38617 is the "scariest" kernel example — kernel-level UAF, no
   toolkit bug needed
-- CVE-2026-5747 (fresh this week, 2026-04-07) widens the point: the class
-  of bug is not confined to kernel + runtime + GPU toolkit — it also
-  shows up in the VMM layer underneath microVM sandboxes (Firecracker's
-  virtio-pci transport, reported by Anthropic via AWS VDP). Every layer
-  of the shared / host-userspace stack keeps producing the same class.
-- The point isn't to memorise CVE numbers, it's to show cadence:
-  this keeps happening, and will keep happening
+
+[CVE-2026-5747 — VMM layer widens the point]
+- Now bring in the newest row on the table. CVE-2026-5747 dropped a week
+  ago — 7th April — and it's not a kernel bug, not a runtime bug, not a
+  GPU toolkit bug. It's in Firecracker's virtio-pci transport: the device
+  model that sits between a guest VM and the host.
+- What happens: a guest with root can craft a malicious PCI config write
+  that triggers an out-of-bounds write in the VMM process on the host.
+  That VMM process runs in host userspace with access to guest memory —
+  so an OOB write there is one step from host-level code execution.
+- Why this matters for the talk: we've just shown the audience kernel
+  escapes, runtime escapes, and GPU toolkit escapes. This CVE shows the
+  same class of shared-resource bug in the VMM layer — the very layer
+  that microVM sandboxes add to improve isolation. Even the "fix" has
+  attack surface.
+- The architectural lesson to land: the argument is not "microVMs have
+  no bugs." It's about where bugs land. A VMM bug in Firecracker affects
+  the host-userspace process for one workload. A kernel bug affects every
+  tenant on the node. Blast radius is the difference.
+- Disclosure context: reported by Anthropic's security team via AWS's
+  Vulnerability Disclosure Program. Anthropic runs Firecracker at scale
+  for their AI workloads — they found this in production-grade usage.
+  Fix shipped in Firecracker 1.14.4 / 1.15.1 for anyone running
+  --enable-pci.
+
+[Cadence over memorisation — land the pattern]
+- Don't read CVE numbers off the slide. Gesture at the table and make
+  the point about the pattern: "Look at the dates. 2024, 2024, 2025,
+  2025, 2025, 2025, 2026. Every few months, another shared-resource
+  escape. Different component each time — runtime, kernel, GPU toolkit,
+  VMM — but the same class of bug."
+- The message to land clearly: this is not a one-off. This is the new
+  normal. The shared-resource stack (kernel, runtime, device model, GPU
+  passthrough) keeps producing escapes because it's large, complex, and
+  shared. The question is not "will there be another CVE?" — it's "when,
+  and what's in the blast radius when it hits?"
+- This sets up the second half of the talk: microVMs don't eliminate
+  bugs, they shrink the blast radius. The audience should leave this
+  slide thinking "okay, so what do we do about this?" — and the answer
+  is the next section.
+
 - Source: Beganović, "Your Container Is Not a Sandbox" (March 2026);
   CVE-2026-5747 via GHSA-776c-mpj7-jm3r / AWS-2026-015
 - Time check: ~7 minutes in


### PR DESCRIPTION
## Summary

- Expand compressed speaker notes on slide 7 ("This Isn't Theoretical — Recent CVEs") into narrative-ready format
- Two new sections: CVE-2026-5747 VMM-layer talking point and cadence-over-memorisation message
- No changes to slide content (table, heading, footer quote) — speaker notes only

## Test plan

- [x] Pre-commit hooks pass
- [x] `npm run build` succeeds
- [x] `npm run test:smoke` passes (17/17 checks)
- [x] All acceptance criteria from issue #110 met

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)