### PR TITLE
feat(ci): auto-assign opened PRs to denhamparry

### DIFF
--- a/.github/workflows/auto-assign-prs.yml
+++ b/.github/workflows/auto-assign-prs.yml
@@ -23,3 +23,14 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/assignees" \
             -d '{"assignees":["denhamparry"]}'
+      - name: Request review
+        if: github.event.pull_request.user.login != 'denhamparry'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          curl --silent --show-error --fail -X POST \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/requested_reviewers" \
+            -d '{"reviewers":["denhamparry"]}'

--- a/.github/workflows/auto-assign-prs.yml
+++ b/.github/workflows/auto-assign-prs.yml
@@ -1,0 +1,25 @@
+name: Auto-assign PRs
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  assign:
+    name: Assign PR to denhamparry
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add assignee
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          curl --silent --show-error --fail -X POST \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/assignees" \
+            -d '{"assignees":["denhamparry"]}'


### PR DESCRIPTION
## Summary

Adds a lightweight `Auto-assign PRs` workflow (`.github/workflows/auto-assign-prs.yml`) that assigns every newly opened pull request — including those from dependabot and other bots — to `denhamparry`, so all open PRs are trackable from the assignee view.

## How it works

- Triggers on `pull_request_target` with type `opened`
- Calls the GitHub REST API directly with the built-in `GITHUB_TOKEN` to add `denhamparry` as assignee
- Requires only `issues: write` and `pull-requests: write` permissions

## Security note

`pull_request_target` is safe here because the job **never checks out or executes PR code** — it only makes a single API call using the event metadata.

## Known limitation

PRs created by other workflows using the default `GITHUB_TOKEN` will **not** trigger this workflow (a GitHub limitation to prevent recursive workflow runs). PRs opened by users, dependabot, and GitHub Apps with their own tokens are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
